### PR TITLE
Added verbose output

### DIFF
--- a/beanstalkd.c
+++ b/beanstalkd.c
@@ -27,8 +27,8 @@
 static char *user = NULL;
 static int detach = 0;
 static char *port = "11300";
-static char *host_addr = "0.0.0.0";
-static int verbose = 0;
+static char *host_addr;
+int verbose = 0;
 
 static void
 nullfd(int fd, int flags)

--- a/prot.c
+++ b/prot.c
@@ -250,8 +250,6 @@ static int drain_mode = 0;
 static usec started_at;
 static uint64_t op_ct[TOTAL_OPS], timeout_ct = 0;
 
-static int *verbose;
-
 /* Doubly-linked list of connections with at least one reserved job. */
 static struct conn running = { &running, &running, 0 };
 
@@ -1818,9 +1816,8 @@ h_accept(const int fd, const short which, struct event *ev)
 }
 
 void
-prot_init(int *v)
+prot_init()
 {
-    verbose = v;
     started_at = now_usec();
     memset(op_ct, 0, sizeof(op_ct));
 

--- a/util.h
+++ b/util.h
@@ -36,6 +36,7 @@ void warn(const char *fmt, ...);
 void warnx(const char *fmt, ...);
 
 extern char *progname;
+extern int verbose;
 
 #define twarn(fmt, args...) warn("%s:%d in %s: " fmt, \
                                  __FILE__, __LINE__, __func__, ##args)


### PR DESCRIPTION
Hi there,

I got rid of the version message when -v is passed and now that enables verbose output, where incoming messages and other info will be passed into stdout. I saw this in the TODO doc and thought I'd chip in.

It's been a very long time since I've done any C so you'll have to forgive me... my skills are a little rusty.

Thanks,

Jamie
