### PR TITLE
patched ct/gen to make the tests run under OS X

### DIFF
--- a/ct/gen
+++ b/ct/gen
@@ -2,11 +2,19 @@
 
 set -e
 
+# OS X prepends global symbols with _. 
+
+if [[ $(uname) == 'Darwin' ]]; then
+    find_cttest_symbols="cut -d ' ' -f 3 | egrep '^_cttest' | egrep -v '\.eh\$' | sed 's/^_//'"
+else
+    find_cttest_symbols="cut -d ' ' -f 3 | egrep '^cttest'"
+fi
+
 tests() {
     for f in "$@"
     do
         nm $f
-    done | cut -d ' ' -f 3 | egrep '^cttest'
+    done | eval $find_cttest_symbols
 }
 
 ts=`tests "$@" || (echo >&2 no tests found; exit 1)`


### PR DESCRIPTION
OS X's linker prepends _ to global symbols. See [Executing Mach-O Files](http://developer.apple.com/library/mac/#documentation/DeveloperTools/Conceptual/MachOTopics/1-Articles/executing_files.html) .

I patched ct/gen find the cttest symbols correctly on Darwin.

Cheers!
