### PR TITLE
[BUG] broken vers.c generation on os x

### DIFF
--- a/mk/verc.sh
+++ b/mk/verc.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-printf 'const char version[] = "'
-mk/vers.sh
-printf '";\n'
+VERSION=`mk/vers.sh`
+printf "const char version[] = \"$VERSION\";\n"

--- a/mk/vers.sh
+++ b/mk/vers.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-git describe | tr -d '\n' | sed s/^v// | tr - +
+git describe | sed s/^v// | tr - + | tr -d '\n'
 if ! git diff --quiet HEAD
 then printf +mod
 fi


### PR DESCRIPTION
vers.c did not generate correctly on OS X.

Here's a quick patch.

```
ultramarine:beanstalkd jdc$ make
cc    -c -o conn.o conn.c
cc    -c -o file.o file.c
cc    -c -o heap.o heap.c
cc    -c -o job.o job.c
cc    -c -o ms.o ms.c
cc    -c -o net.o net.c
cc    -c -o port-darwin.o port-darwin.c
cc    -c -o primes.o primes.c
cc    -c -o prot.o prot.c
cc    -c -o sd-daemon.o sd-daemon.c
cc    -c -o sock-darwin.o sock-darwin.c
cc    -c -o srv.o srv.c
cc    -c -o time.o time.c
cc    -c -o tube.o tube.c
cc    -c -o util.o util.c
mk/verc.sh >vers.c
cc    -c -o vers.o vers.c
vers.c:1:24: warning: missing terminating " character
vers.c:1: error: missing terminating " character
vers.c:2:1: warning: missing terminating " character
vers.c:2: error: missing terminating " character
vers.c:2: error: expected expression at end of input
make: *** [vers.o] Error 1
ultramarine:beanstalkd jdc$ cat vers.c
const char version[] = "1.4.6+73+g0d632db
";
```
