### PR TITLE
Added the deletion of delayed jobs.

### DIFF
--- a/prot.c
+++ b/prot.c
@@ -608,6 +608,15 @@ remove_buried_job(job j)
 }
 
 static job
+remove_delayed_job(job j)
+{
+    if (!j || j->r.state != Delayed) return NULL;
+    heapremove(&j->tube->delay, j->heap_index);
+
+    return j;
+}
+
+static job
 remove_ready_job(job j)
 {
     if (!j || j->r.state != Ready) return NULL;
@@ -1278,7 +1287,8 @@ dispatch_cmd(conn c)
         j = job_find(id);
         j = remove_reserved_job(c, j) ? :
             remove_ready_job(j) ? :
-            remove_buried_job(j);
+            remove_buried_job(j) ? :
+            remove_delayed_job(j);
 
         if (!j) return reply(c, MSG_NOTFOUND, MSG_NOTFOUND_LEN, STATE_SENDWORD);
 


### PR DESCRIPTION
I'm not sure I did this correctly, or if there was a reason this was never implemented, but I needed it for a project that uses beanstalkd I am working on. I hope I did this correctly.

Also, I modified epoll_create1(0) to epoll_create(1) to be compatible on older systems (like mine). Since Linux 2.6.8 the epoll_create(1) has operated the same as epoll_create1(0) ([Link](http://www.kernel.org/doc/man-pages/online/pages/man2/epoll_create.2.html)).
