### PR TITLE
Error in sysv init script

### DIFF
--- a/adm/sysv/beanstalkd.init
+++ b/adm/sysv/beanstalkd.init
@@ -61,7 +61,7 @@ start() {
         fi
     fi
 
-    daemon $exec -d $options
+    daemon $exec $options &
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile


### PR DESCRIPTION
Hi

Where you have removed the -d option.

I was getting "Starting beanstalkd: /usr/bin/beanstalkd: unknown option: -d", when using the sysv init script.

I have updated it to use "&" to background.

Thanks
Steven
