### PR TITLE
Unbuffered stdout

### DIFF
--- a/main.c
+++ b/main.c
@@ -53,6 +53,7 @@ main(int argc, char **argv)
     struct job list = {};
 
     progname = argv[0];
+    setvbuf(stdout, NULL, _IONBF, 0);
     optparse(&srv, argv+1);
 
     if (verbose) {


### PR DESCRIPTION
Beanstalkd logs verbose (debugging) output to stdout.
Unbuffered stdout will improve debug info capturing.

Here is a particular problem that I had.

I am using foreman (https://github.com/ddollar/foreman) to start beanstalk:
beanstalk: vendor/bin/beanstalkd -l 127.0.0.1 -p 11300 -V -V -V

With buffered stdout, foreman does not capture the verbose output from beanstalkd.
E.g. all I see is
11:07:57 beanstalk.1  | started with pid 53516

With unbuffered stdout, foreman shows all verbose output from beanstalkd:
11:18:35 beanstalk.1  | started with pid 53837
11:18:35 beanstalk.1  | pid 53837
11:18:35 beanstalk.1  | bind 3 127.0.0.1:11300
11:30:39 beanstalk.1  | accept 11
11:30:39 beanstalk.1  | <11 command list-tubes-watched
11:30:39 beanstalk.1  | >11 reply OK 14
11:30:39 beanstalk.1  | >11 job 0
11:30:39 beanstalk.1  | <11 command watch 
11:30:39 beanstalk.1  | >11 reply WATCHING 2
11:30:39 beanstalk.1  | <11 command use 
11:30:39 beanstalk.1  | >11 reply USING cluster1
11:30:39 beanstalk.1  | <11 command ignore 
11:30:39 beanstalk.1  | >11 reply WATCHING 1
11:30:39 beanstalk.1  | <11 command reserve
