### PR TITLE
Fix for #134

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -143,7 +143,13 @@ connwant(Conn *c, int rw)
 void
 connsched(Conn *c)
 {
+    void *r = NULL;
+
+    if (c->tickpos > -1)
+        r = heapremove(&c->srv->conns, c->tickpos);
     c->tickat = conntickat(c);
+    if (r)
+        heapinsert(&c->srv->conns, c);
     srvschedconn(c->srv, c);
 }
 


### PR DESCRIPTION
Remove the connection from the heap before changing its tickat value.  Then
reinsert it if necessary so the connections heap ordering is not altered.  This
should close #134 and, maybe, a bunch of other infinite loops and segmentation
fault issues.
