### PR TITLE
AF_UNIX support for beanstalkd

### DIFF
--- a/doc/beanstalkd.1
+++ b/doc/beanstalkd.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BEANSTALKD" "1" "April 2012" "" ""
+.TH "BEANSTALKD" "1" "August 2019" "" ""
 .
 .SH "NAME"
 \fBbeanstalkd\fR \- simple, fast work queue
@@ -55,6 +55,9 @@ Show a brief help message and exit\.
 .TP
 \fB\-l\fR \fIaddr\fR
 Listen on address \fIaddr\fR (default is 0\.0\.0\.0)\.
+.
+.IP
+When \fIaddr\fR starts with "unix:", the unprefixed value of it will be used as the local filesystem path to create a UNIX socket instead of a TCP socket\. In this case the value of \fB\-p\fR will be ignored\.
 .
 .IP
 (Option \fB\-l\fR has no effect if sd\-daemon(5) socket activation is being used\. See also \fIENVIRONMENT\fR\.)

--- a/doc/beanstalkd.1.html
+++ b/doc/beanstalkd.1.html
@@ -121,6 +121,10 @@ it writes to the binlog.</p>
 <dt class="flush"><code>-h</code></dt><dd><p>Show a brief help message and exit.</p></dd>
 <dt class="flush"><code>-l</code> <var>addr</var></dt><dd><p>Listen on address <var>addr</var> (default is 0.0.0.0).</p>
 
+<p>When <var>addr</var> starts with "unix:", the unprefixed value of it will be
+used as the local filesystem path to create a UNIX socket instead of
+a TCP socket. In this case the value of <code>-p</code> will be ignored.</p>
+
 <p>(Option <code>-l</code> has no effect if <span class="man-ref">sd-daemon<span class="s">(5)</span></span> socket activation is
 being used. See also <a href="#ENVIRONMENT" title="ENVIRONMENT" data-bare-link="true">ENVIRONMENT</a>.)</p></dd>
 <dt class="flush"><code>-n</code></dt><dd><p>Turn off binlog compaction, negating <code>-c</code>.</p>
@@ -167,7 +171,7 @@ of many others.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>April 2012</li>
+    <li class='tc'>August 2019</li>
     <li class='tr'>beanstalkd(1)</li>
   </ol>
 

--- a/doc/beanstalkd.ronn
+++ b/doc/beanstalkd.ronn
@@ -59,6 +59,10 @@ and format of the `beanstalkd` protocol.
 * `-l` <addr>:
   Listen on address <addr> (default is 0.0.0.0).
 
+  When <addr> starts with "unix:", the unprefixed value of it will be
+  used as the local filesystem path to create a UNIX socket instead of
+  a TCP socket. In this case the value of `-p` will be ignored.
+
   (Option `-l` has no effect if sd-daemon(5) socket activation is
   being used. See also [ENVIRONMENT][].)
 

--- a/net.c
+++ b/net.c
@@ -7,19 +7,205 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/stat.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 
-int
-make_server_socket(char *host, char *port)
+static int
+set_nonblocking(int fd)
+{
+    int flags, r;
+
+    flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0) {
+        twarn("getting flags");
+        return -1;
+    }
+    r = fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+    if (r == -1) {
+        twarn("setting O_NONBLOCK");
+        return -1;
+    }
+    return 0;
+}
+
+static int
+make_inet_socket(char *host, char *port)
 {
     int fd = -1, flags, r;
     struct linger linger = {0, 0};
     struct addrinfo *airoot, *ai, hints;
 
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = PF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+    r = getaddrinfo(host, port, &hints, &airoot);
+    if (r != 0) {
+        twarnx("getaddrinfo(): %s", gai_strerror(r));
+        return -1;
+    }
+
+    for (ai = airoot; ai; ai = ai->ai_next) {
+        fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+        if (fd == -1) {
+            twarn("socket()");
+            continue;
+        }
+
+        r = set_nonblocking(fd);
+        if (r == -1) {
+            close(fd);
+            continue;
+        }
+
+        flags = 1;
+        r = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &flags, sizeof flags);
+        if (r == -1) {
+            twarn("setting SO_REUSEADDR on fd %d", fd);
+            close(fd);
+            continue;
+        }
+        r = setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &flags, sizeof flags);
+        if (r == -1) {
+            twarn("setting SO_KEEPALIVE on fd %d", fd);
+            close(fd);
+            continue;
+        }
+        r = setsockopt(fd, SOL_SOCKET, SO_LINGER, &linger, sizeof linger);
+        if (r == -1) {
+            twarn("setting SO_LINGER on fd %d", fd);
+            close(fd);
+            continue;
+        }
+        r = setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flags, sizeof flags);
+        if (r == -1) {
+            twarn("setting TCP_NODELAY on fd %d", fd);
+            close(fd);
+            continue;
+        }
+
+        r = bind(fd, ai->ai_addr, ai->ai_addrlen);
+        if (r == -1) {
+            twarn("bind()");
+            close(fd);
+            continue;
+        }
+        if (verbose) {
+            char hbuf[NI_MAXHOST], pbuf[NI_MAXSERV], *h = host, *p = port;
+            struct sockaddr_in addr;
+            socklen_t addrlen;
+
+            addrlen = sizeof(addr);
+            r = getsockname(fd, (struct sockaddr *) &addr, &addrlen);
+            if (!r) {
+                r = getnameinfo((struct sockaddr *) &addr, addrlen,
+                                hbuf, sizeof(hbuf),
+                                pbuf, sizeof(pbuf),
+                                NI_NUMERICHOST|NI_NUMERICSERV);
+                if (!r) {
+                    h = hbuf;
+                    p = pbuf;
+                }
+            }
+            if (ai->ai_family == AF_INET6) {
+                printf("bind %d [%s]:%s\n", fd, h, p);
+            } else {
+                printf("bind %d %s:%s\n", fd, h, p);
+            }
+        }
+
+        r = listen(fd, 1024);
+        if (r == -1) {
+            twarn("listen()");
+            close(fd);
+            continue;
+        }
+
+        break;
+    }
+
+    freeaddrinfo(airoot);
+
+    if(ai == NULL)
+        fd = -1;
+
+    return fd;
+}
+
+static int
+make_unix_socket(char *path)
+{
+    int fd = -1, r;
+    struct stat st;
+    struct sockaddr_un addr;
+    const size_t maxlen = sizeof(addr.sun_path) - 1; // Reserve the last position for '\0'
+
+    memset(&addr, 0, sizeof(struct sockaddr_un));
+    addr.sun_family = AF_UNIX;
+    if (strlen(path) > maxlen) {
+        warnx("socket path %s is too long (%ld characters), where maximum allowed is %ld",
+              path, strlen(path), maxlen);
+        return -1;
+    }
+    strncpy(addr.sun_path, path, maxlen);
+
+    r = stat(path, &st);
+    if (r == 0) {
+        if (S_ISSOCK(st.st_mode)) {
+            warnx("removing existing local socket to replace it");
+            r = unlink(path);
+            if (r == -1) {
+                twarn("unlink");
+                return -1;
+            }
+        } else {
+            twarnx("another file already exists in the given path");
+            return -1;
+        }
+    }
+
+    fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd == -1) {
+        twarn("socket()");
+        return -1;
+    }
+
+    r = set_nonblocking(fd);
+    if (r == -1) {
+        close(fd);
+        return -1;
+    }
+
+    r = bind(fd, (struct sockaddr *) &addr, sizeof(struct sockaddr_un));
+    if (r == -1) {
+        twarn("bind()");
+        close(fd);
+        return -1;
+    }
+    if (verbose) {
+        printf("bind %d %s\n", fd, path);
+    }
+
+    r = listen(fd, 1024);
+    if (r == -1) {
+        twarn("listen()");
+        close(fd);
+        return -1;
+    }
+
+    return fd;
+}
+
+int
+make_server_socket(char *host, char *port)
+{
+    int fd = -1, r;
+
     /* See if we got a listen fd from systemd. If so, all socket options etc
-     * are already set, so we check that the fd is a TCP listen socket and
-     * return. */
+     * are already set, so we check that the fd is a TCP or UNIX listen socket
+     * and return. */
     r = sd_listen_fds(1);
     if (r < 0) {
         return twarn("sd_listen_fds"), -1;
@@ -32,118 +218,28 @@ make_server_socket(char *host, char *port)
         fd = SD_LISTEN_FDS_START;
         r = sd_is_socket_inet(fd, 0, SOCK_STREAM, 1, 0);
         if (r < 0) {
-            errno = -r;
             twarn("sd_is_socket_inet");
+            errno = -r;
             return -1;
         }
-        if (!r) {
-            twarnx("inherited fd is not a TCP listen socket");
-            return -1;
+        if (r == 0) {
+            r = sd_is_socket_unix(fd, SOCK_STREAM, 1, NULL, 0);
+            if (r < 0) {
+                twarn("sd_is_socket_unix");
+                errno = -r;
+                return -1;
+            }
+            if (r == 0) {
+                twarnx("inherited fd is not a TCP or UNIX listening socket");
+                return -1;
+            }
         }
         return fd;
     }
 
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_family = PF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-    hints.ai_flags = AI_PASSIVE;
-    r = getaddrinfo(host, port, &hints, &airoot);
-    if (r != 0) {
-      twarnx("getaddrinfo(): %s", gai_strerror(r));
-      return -1;
+    if (host && !strncmp(host, "unix:", 5)) {
+        return make_unix_socket(&host[5]);
+    } else {
+        return make_inet_socket(host, port);
     }
-
-    for(ai = airoot; ai; ai = ai->ai_next) {
-      fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
-      if (fd == -1) {
-        twarn("socket()");
-        continue;
-      }
-
-      flags = fcntl(fd, F_GETFL, 0);
-      if (flags < 0) {
-        twarn("getting flags");
-        close(fd);
-        continue;
-      }
-
-      r = fcntl(fd, F_SETFL, flags | O_NONBLOCK);
-      if (r == -1) {
-        twarn("setting O_NONBLOCK");
-        close(fd);
-        continue;
-      }
-
-      flags = 1;
-      r = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &flags, sizeof flags);
-      if (r == -1) {
-        twarn("setting SO_REUSEADDR on fd %d", fd);
-        close(fd);
-        continue;
-      }
-      r = setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &flags, sizeof flags);
-      if (r == -1) {
-        twarn("setting SO_KEEPALIVE on fd %d", fd);
-        close(fd);
-        continue;
-      }
-      r = setsockopt(fd, SOL_SOCKET, SO_LINGER, &linger, sizeof linger);
-      if (r == -1) {
-        twarn("setting SO_LINGER on fd %d", fd);
-        close(fd);
-        continue;
-      }
-      r = setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flags, sizeof flags);
-      if (r == -1) {
-        twarn("setting TCP_NODELAY on fd %d", fd);
-        close(fd);
-        continue;
-      }
-
-      r = bind(fd, ai->ai_addr, ai->ai_addrlen);
-      if (r == -1) {
-        twarn("bind()");
-        close(fd);
-        continue;
-      }
-      if (verbose) {
-          char hbuf[NI_MAXHOST], pbuf[NI_MAXSERV], *h = host, *p = port;
-         struct sockaddr_in addr;
-         socklen_t addrlen;
-
-         addrlen = sizeof(addr);
-         r = getsockname(fd, (struct sockaddr *) &addr, &addrlen);
-         if (!r) {
-             r = getnameinfo((struct sockaddr *) &addr, addrlen,
-                             hbuf, sizeof(hbuf),
-                             pbuf, sizeof(pbuf),
-                             NI_NUMERICHOST|NI_NUMERICSERV);
-             if (!r) {
-                 h = hbuf;
-                 p = pbuf;
-             }
-         }
-          if (ai->ai_family == AF_INET6) {
-              printf("bind %d [%s]:%s\n", fd, h, p);
-          } else {
-              printf("bind %d %s:%s\n", fd, h, p);
-          }
-      }
-
-      r = listen(fd, 1024);
-      if (r == -1) {
-        twarn("listen()");
-        close(fd);
-        continue;
-      }
-
-      break;
-    }
-
-    freeaddrinfo(airoot);
-
-    if(ai == NULL)
-      fd = -1;
-
-    return fd;
 }

--- a/prot.c
+++ b/prot.c
@@ -11,7 +11,6 @@
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <sys/socket.h>
-#include <netinet/in.h>
 #include <inttypes.h>
 #include <stdarg.h>
 #include <signal.h>
@@ -2112,7 +2111,7 @@ void
 h_accept(const int fd, const short which, Server *s)
 {
     UNUSED_PARAMETER(which);
-    struct sockaddr_in6 addr;
+    struct sockaddr_storage addr;
 
     socklen_t addrlen = sizeof addr;
     int cfd = accept(fd, (struct sockaddr *)&addr, &addrlen);

--- a/testserv.c
+++ b/testserv.c
@@ -10,6 +10,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/select.h>
+#include <sys/un.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>
@@ -29,6 +30,15 @@ static int64 timeout = 5000000000LL;
 // should fail with ENOSPC result.
 static byte fallocpat[3];
 
+
+static int
+exist(char *path)
+{
+    struct stat s;
+
+    int r = stat(path, &s);
+    return r != -1;
+}
 
 static int
 wrapfalloc(int fd, int size)
@@ -100,6 +110,29 @@ mustdiallocal(int port)
     return fd;
 }
 
+static int
+mustdialunix(char *socket_file)
+{
+    struct sockaddr_un addr;
+    const size_t maxlen = sizeof(addr.sun_path);
+    addr.sun_family = AF_UNIX;
+    snprintf(addr.sun_path, maxlen, "%s", socket_file);
+
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd == -1) {
+        twarn("socket");
+        exit(1);
+    }
+
+    int r = connect(fd, (struct sockaddr *)&addr, sizeof addr);
+    if (r == -1) {
+        twarn("connect");
+        exit(1);
+    }
+
+    return fd;
+}
+
 static void
 exit_process(int signum)
 {
@@ -142,6 +175,7 @@ kill_srvpid(void)
 }
 
 #define SERVER() (progname=__func__, mustforksrv())
+#define SERVER_UNIX() (progname=__func__, mustforksrv_unix())
 
 // Forks the server storing the pid in srvpid.
 // The parent process returns port assigned.
@@ -176,6 +210,44 @@ mustforksrv(void)
         atexit(kill_srvpid);
         printf("start server port=%d pid=%d\n", port, srvpid);
         return port;
+    }
+
+    /* now in child */
+
+    set_sig_handler();
+    prot_init();
+
+    srv_acquire_wal(&srv);
+
+    srvserve(&srv); /* does not return */
+    exit(1); /* satisfy the compiler */
+}
+
+static char *
+mustforksrv_unix(void)
+{
+    static char path[90];
+    char name[95];
+    snprintf(path, sizeof(path), "%s/socket", ctdir());
+    snprintf(name, sizeof(name), "unix:%s", path);
+    srv.sock.fd = make_server_socket(name, NULL);
+    if (srv.sock.fd == -1) {
+        puts("mustforksrv_unix failed");
+        exit(1);
+    }
+
+    srvpid = fork();
+    if (srvpid < 0) {
+        twarn("fork");
+        exit(1);
+    }
+
+    if (srvpid > 0) {
+        // On exit the parent (test) sends SIGTERM to the child.
+        atexit(kill_srvpid);
+        printf("start server socket=%s\n", path);
+        assert(exist(path));
+        return path;
     }
 
     /* now in child */
@@ -293,15 +365,6 @@ filesize(char *path)
     return s.st_size;
 }
 
-static int
-exist(char *path)
-{
-    struct stat s;
-
-    int r = stat(path, &s);
-    return r != -1;
-}
-
 void
 cttest_unknown_command()
 {
@@ -361,6 +424,31 @@ cttest_peek_not_found()
     ckresp(fd, "NOT_FOUND\r\n");
     mustsend(fd, "peek 18446744073709551615\r\n");  // UINT64_MAX
     ckresp(fd, "NOT_FOUND\r\n");
+}
+
+void
+cttest_peek_ok_unix()
+{
+    char *name = SERVER_UNIX();
+    int fd = mustdialunix(name);
+    mustsend(fd, "put 0 0 1 1\r\n");
+    mustsend(fd, "a\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
+
+    mustsend(fd, "peek 1\r\n");
+    ckresp(fd, "FOUND 1 1\r\n");
+    ckresp(fd, "a\r\n");
+
+    unlink(name);
+}
+
+void
+cttest_unix_auto_removal()
+{
+    // Twice, to trigger autoremoval
+    SERVER_UNIX();
+    kill_srvpid();
+    SERVER_UNIX();
 }
 
 void


### PR DESCRIPTION
Add the posibility of accepting connections from a local socket (bound to a filesystem path).

To minimize portability issues, socket paths longer than 100 bytes are rejected.  Systemd support has been added too, but not tested as I don't have access to any Fedora or similar.

The behaviour of the new command line switch may be strange, but it has been implemented in a way to avoid script breakage when this option is not used.

The automatic socket file replacement may be a bit surprising too.  However, I found that implementing an automatic removal/cleanup on exit was a bit more intrusive.

Any feedback will be appreciated.
