### PR TITLE
Adds reserve-with-nano-timeout command.

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -121,7 +121,7 @@ conntickat(Conn *c)
         should_timeout = 1;
     }
     if (c->pending_timeout >= 0) {
-        t = min(t, ((int64)c->pending_timeout) * 1000000000);
+        t = min(t, c->pending_timeout);
         should_timeout = 1;
     }
 

--- a/dat.h
+++ b/dat.h
@@ -273,7 +273,7 @@ struct Conn {
     int    tickpos;     // position in srv->conns
     job    soonest_job; // memoization of the soonest job
     int    rw;          // currently want: 'r', 'w', or 'h'
-    int    pending_timeout;
+    int64  pending_timeout;
     char   halfclosed;
 
     char cmd[LINE_BUF_SIZE]; // this string is NOT NUL-terminated

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -165,6 +165,8 @@ was received first.
 
 A timeout value of `0` will cause the server to immediately return either a response or `TIMED_OUT`.  A positive value of timeout will limit the amount of time the client will block on the reserve request until a job becomes available.
 
+Note that you can specify a fractional amount of seconds, like '0.01' for 10 ms. While in theory, you could specify timeouts with a precision of one nanosecond this way, in practice you're limited to minimum values of around 0.015 seconds.
+
 ##### `reserve` responses
 
 ###### Non-succesful responses

--- a/prot.c
+++ b/prot.c
@@ -1001,7 +1001,7 @@ read_tube_name(char **tubename, char *buf, char **end)
 }
 
 static void
-wait_for_job(Conn *c, int timeout)
+wait_for_job(Conn *c, int64 timeout)
 {
     c->state = STATE_WAIT;
     enqueue_waiting_conn(c);
@@ -1181,7 +1181,7 @@ prot_remove_tube(tube t)
 }
 
 static void
-wait_and_process_job(Conn *c, int timeout)
+wait_and_process_job(Conn *c, int64 timeout)
 {
     connsetworker(c);
 
@@ -1194,10 +1194,61 @@ wait_and_process_job(Conn *c, int timeout)
     process_queue();
 }
 
+int64
+parse_fractional_seconds(char* buffer)
+{
+    /* Assumes that buffer is 0 terminated correctly. Returns -1 if parser
+     * fails. */
+
+    int64 timeout = -1;
+    char *frac_buf, *end_buf; 
+    uint fractional_part_size;
+
+    // Interpret the seconds part of the timeout argument
+    timeout = strtol(buffer, &end_buf, 10);
+    timeout *= 1000000000;      // convert to nanoseconds
+    if (errno) return -1;
+
+    /* If we haven't hit EOS yet, let's try to read a fractional part of the 
+     * seconds argument: */
+    if (*end_buf != '\0') {
+        // Anything else but a '.' is an error here.
+        if (*end_buf != '.') return -1;
+
+        frac_buf = end_buf + 1;
+        fractional_part_size = strlen(frac_buf);   
+        
+        if (fractional_part_size > 9) return -1;
+        if (fractional_part_size > 0) {
+            if (*frac_buf < '0' || *frac_buf > '9') return -1;
+            // assert: frac_buf begins with at least one digit.
+
+            /* Parses the fractional part. If frac_buf is not completely 
+             * consumed (advanced to point to the '\0'), there were chars
+             * other than digits here, we consider that an error. */
+            int64 fract = strtol(frac_buf, &end_buf, 10);
+            if (errno) return -1;
+            if (*end_buf != '\0') return -1;
+
+            /* We know now that frac_buf contained only numbers and that
+             * it contained fractional_part_size numbers. Also, there
+             * were less than 10 digits. Performs a fixed point addition.
+             */
+            for (uint i=fractional_part_size; i<9; i++) {
+                fract *= 10;
+            }
+            timeout += fract; 
+        }
+    }
+
+    return timeout; 
+}
+
 static void
 dispatch_cmd(Conn *c)
 {
-    int r, i, timeout = -1;
+    int r, i;
+    int64 timeout = -1;
     int z;
     uint count;
     job j = 0;
@@ -1327,8 +1378,9 @@ dispatch_cmd(Conn *c)
         break;
     case OP_RESERVE_TIMEOUT:
         errno = 0;
-        timeout = strtol(c->cmd + CMD_RESERVE_TIMEOUT_LEN, &end_buf, 10);
-        if (errno) return reply_msg(c, MSG_BAD_FORMAT);
+
+        timeout = parse_fractional_seconds(c->cmd + CMD_RESERVE_TIMEOUT_LEN);
+        if (timeout < 0) return reply_msg(c, MSG_BAD_FORMAT);
 
         op_ct[type]++;
         wait_and_process_job(c, timeout);


### PR DESCRIPTION
reserve-with-nano-timeout will act the same as reserve-with-timeout,
except that the timeout number specifies nanoseconds.

This is split in two commits: one to refactor the existing timeout infrastructure and one to add the new feature. 

(with thanks to Yves Senn (@senny) for the Pair Programming)
