### PR TITLE
Build fails on debian's gnu/Hurd-i386 arch

### DIFF
--- a/walg.c
+++ b/walg.c
@@ -405,15 +405,18 @@ waldirlock(Wal *w)
     int r;
     int fd;
     struct flock lk;
-    char path[PATH_MAX];
+    char *path;
+    size_t path_length;
 
-    r = snprintf(path, PATH_MAX, "%s/lock", w->dir);
-    if (r > PATH_MAX) {
-        twarnx("path too long: %s/lock", w->dir);
+    path_length = strlen(w->dir) + strlen("/lock") + 1;
+    if ((path = malloc(path_length)) == NULL) {
+        twarn("malloc");
         return 0;
     }
+    r = snprintf(path, path_length, "%s/lock", w->dir);
 
     fd = open(path, O_WRONLY|O_CREAT, 0600);
+    free(path);
     if (fd == -1) {
         twarn("open");
         return 0;


### PR DESCRIPTION
Hello,

As you can see in https://buildd.debian.org/status/fetch.php?pkg=beanstalkd&arch=hurd-i386&ver=1.8-1&stamp=1365546488 beanstalkd fails to build in hurd-i386 with: `walg.c:408:15: error: 'PATH_MAX' undeclared (first use in this function)` 
because there is no upper limit in pathnames. 
http://www.gnu.org/software/hurd/hurd/porting/guidelines.html#PATH_MAX_tt_MAX_PATH_tt_MAXPATHL suggests using dynamic allocation of memory.

I have written a patch and intend to include it in the next release of beanstalkd package. Could you please consider incorporating it upstream so i can drop the debian-specific patch sometime in the future?
