### PR TITLE
Add DESTDIR support to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
+DESTDIR=
 PREFIX=/usr/local
-BINDIR=$(PREFIX)/bin
+BINDIR=$(DESTDIR)$(PREFIX)/bin
 CFLAGS=-Wall -Werror\
 	-Wformat=2\
 	-g\


### PR DESCRIPTION
This commit adds support for building packages using debuild. It does not negatively affect other build processes, as the injection of $(DESTDIR) is a no-op otherwise.
