### PR TITLE
Cleanup of Makefile to be able to set Flags from packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 DESTDIR=
-PREFIX=/usr/local
+PREFIX?=/usr/local
 BINDIR=$(DESTDIR)$(PREFIX)/bin
-CFLAGS=-Wall -Werror\
+CFLAGS?=-Wall -Werror\
 	-Wformat=2\
 	-g\
 
-LDFLAGS=
 OS=$(shell uname|tr A-Z a-z)
 INSTALL=install
 


### PR DESCRIPTION
Based on [@gregoryp work](http://anonscm.debian.org/gitweb/?p=collab-maint/beanstalkd.git;a=blob;f=debian/patches/0002-Sanitize-Makefile.patch;h=185bb088cf0f72b5122341b7219cd27c10fb25d5;hb=HEAD)
This let use set a different PRFEFIX and CFLAGS from debhelper script (to build debian package).
This will not impact other usage.
