### PR TITLE
Add Command: "wait <id>" that responds when a job is deleted

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -51,6 +51,8 @@ make_conn(int fd, char start_state, tube use, tube watch)
     c->tickpos = -1;
     j = &c->reserved_jobs;
     j->prev = j->next = j;
+    c->next_waitjob = NULL;
+
 
     /* stats */
     cur_conn_ct++;

--- a/dat.h
+++ b/dat.h
@@ -149,6 +149,7 @@ struct job {
     void *reserver;
     int walresv;
     int walused;
+    Conn *waitjob_conn;
 
     char body[]; // written separately to the wal
 };
@@ -268,6 +269,7 @@ struct Conn {
     char   state;
     char   type;
     Conn   *next;
+    Conn   *next_waitjob;
     tube   use;
     int64  tickat;      // time at which to do more work
     int    tickpos;     // position in srv->conns

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -229,6 +229,28 @@ The client expects one line of response, which may be:
 * `BURIED\r\n` if the server ran out of memory trying to grow the priority queue data structure.
 * `NOT_FOUND\r\n` if the job does not exist or is not reserved by the client.
 
+#### `wait` command
+
+The wait command waits until a particular job is out of the system before responding. It can be used to block a client until a job is completed. It looks like this:
+
+```
+wait <id>\r\n
+```
+
+##### `wait` options
+
+* `<id>` is the job id to wait for.
+
+##### `wait` responses
+
+The client expects one line of response once the state of the job has changed, which may be:
+
+* `DELETED <id>\r\n` to indicate the job was deleted via the `delete` command (normal success).
+* `BURIED <id>\r\n` to indicate the job was buried via the `bury` command.
+* `NOT_FOUND\r\n` if the job id does not exist.
+
+A response won't be sent by the server until the specified job is deleted or buried. The wait command can be issued multiple times before a response is received in order to wait on a collection of jobs.
+
 #### `bury` command
 The bury command puts a job into the "buried" state. Buried jobs are put into a FIFO linked list and will not be touched by the server again until a client kicks them with the `kick`" command.
 

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -287,6 +287,28 @@ The client expects one line of response, which may be:
 
  - "NOT_FOUND\r\n" if the job does not exist or is not reserved by the client.
 
+The wait command waits until a particular job is out of the system before
+responding. It can be used to block a client until a job is completed. the wait
+command looks like this:
+
+wait <id>\r\n
+
+- <id> is the job id to wait for.
+
+The client expects one line of response once the state of the job has changed,
+which may be:
+
+ - "DELETED <id>\r\n" to indicate the job was deleted via the 'delete' command
+   (normal success).
+
+ - "BURIED <id>\r\n" to indicate the job was buried via the 'bury' command.
+
+ - "NOT_FOUND\r\n" if the job id does not exist.
+
+A response won't be sent by the server until the specified job is deleted or
+buried. The wait command can be issued multiple times before a response is
+received in order to wait on a collection of jobs. 
+
 The bury command puts a job into the "buried" state. Buried jobs are put into a
 FIFO linked list and will not be touched by the server again until a client
 kicks them with the "kick" command.

--- a/prot.c
+++ b/prot.c
@@ -24,6 +24,7 @@ size_t job_data_size_limit = JOB_DATA_SIZE_LIMIT_DEFAULT;
     "0123456789-+/;.$_()"
 
 #define CMD_PUT "put "
+#define CMD_WAITJOB "wait "
 #define CMD_PEEKJOB "peek "
 #define CMD_PEEK_READY "peek-ready"
 #define CMD_PEEK_DELAYED "peek-delayed"
@@ -50,6 +51,8 @@ size_t job_data_size_limit = JOB_DATA_SIZE_LIMIT_DEFAULT;
 
 #define CONSTSTRLEN(m) (sizeof(m) - 1)
 
+
+#define CMD_WAITJOB_LEN CONSTSTRLEN(CMD_WAITJOB)
 #define CMD_PEEK_READY_LEN CONSTSTRLEN(CMD_PEEK_READY)
 #define CMD_PEEK_DELAYED_LEN CONSTSTRLEN(CMD_PEEK_DELAYED)
 #define CMD_PEEK_BURIED_LEN CONSTSTRLEN(CMD_PEEK_BURIED)
@@ -86,6 +89,7 @@ size_t job_data_size_limit = JOB_DATA_SIZE_LIMIT_DEFAULT;
 #define MSG_BURIED_FMT "BURIED %"PRIu64"\r\n"
 #define MSG_INSERTED_FMT "INSERTED %"PRIu64"\r\n"
 #define MSG_NOT_IGNORED "NOT_IGNORED\r\n"
+#define MSG_WAITED_FMT "WAITED %"PRIu64"\r\n"
 
 #define MSG_NOTFOUND_LEN CONSTSTRLEN(MSG_NOTFOUND)
 #define MSG_DELETED_LEN CONSTSTRLEN(MSG_DELETED)
@@ -136,7 +140,8 @@ size_t job_data_size_limit = JOB_DATA_SIZE_LIMIT_DEFAULT;
 #define OP_QUIT 22
 #define OP_PAUSE_TUBE 23
 #define OP_JOBKICK 24
-#define TOTAL_OPS 25
+#define OP_WAITJOB 25
+#define TOTAL_OPS 26
 
 #define STATS_FMT "---\n" \
     "current-jobs-urgent: %u\n" \
@@ -145,6 +150,7 @@ size_t job_data_size_limit = JOB_DATA_SIZE_LIMIT_DEFAULT;
     "current-jobs-delayed: %u\n" \
     "current-jobs-buried: %u\n" \
     "cmd-put: %" PRIu64 "\n" \
+    "cmd-wait: %" PRIu64 "\n" \
     "cmd-peek: %" PRIu64 "\n" \
     "cmd-peek-ready: %" PRIu64 "\n" \
     "cmd-peek-delayed: %" PRIu64 "\n" \
@@ -273,6 +279,7 @@ static const char * op_names[] = {
     CMD_QUIT,
     CMD_PAUSE_TUBE,
     CMD_JOBKICK,
+    CMD_WAITJOB,
 };
 
 static job remove_buried_job(job j);
@@ -528,6 +535,21 @@ enqueue_reserved_jobs(Conn *c)
     }
 }
 
+void notify_waiting_conns(job j) {
+
+   Conn *c = j->waitjob_conn;
+   Conn *prev_c;
+   while (c) {
+      reply_line(c, STATE_SENDWORD, MSG_WAITED_FMT, j->r.id);
+
+      prev_c = c;
+      c = c->next_waitjob;
+      prev_c->next_waitjob = NULL;
+   }
+
+   j->waitjob_conn = NULL;
+}
+
 static job
 delay_q_take()
 {
@@ -740,6 +762,7 @@ which_cmd(Conn *c)
 {
 #define TEST_CMD(s,c,o) if (strncmp((s), (c), CONSTSTRLEN(c)) == 0) return (o);
     TEST_CMD(c->cmd, CMD_PUT, OP_PUT);
+    TEST_CMD(c->cmd, CMD_WAITJOB, OP_WAITJOB);
     TEST_CMD(c->cmd, CMD_PEEKJOB, OP_PEEKJOB);
     TEST_CMD(c->cmd, CMD_PEEK_READY, OP_PEEK_READY);
     TEST_CMD(c->cmd, CMD_PEEK_DELAYED, OP_PEEK_DELAYED);
@@ -891,6 +914,7 @@ fmt_stats(char *buf, size_t size, void *x)
             get_delayed_job_ct(),
             global_stat.buried_ct,
             op_ct[OP_PUT],
+            op_ct[OP_WAITJOB],
             op_ct[OP_PEEKJOB],
             op_ct[OP_PEEK_READY],
             op_ct[OP_PEEK_DELAYED],
@@ -1008,6 +1032,18 @@ wait_for_job(Conn *c, int timeout)
 
     /* Set the pending timeout to the requested timeout amount */
     c->pending_timeout = timeout;
+
+    connwant(c, 'h'); // only care if they hang up
+    c->next = dirty;
+    dirty = c;
+}
+
+static void
+wait_for_job_deleted(Conn *c, job j)
+{
+    c->state = STATE_WAIT;
+    c->next_waitjob = j->waitjob_conn;
+    j->waitjob_conn = c;
 
     connwant(c, 'h'); // only care if they hang up
     c->next = dirty;
@@ -1253,6 +1289,19 @@ dispatch_cmd(Conn *c)
         maybe_enqueue_incoming_job(c);
 
         break;
+    case OP_WAITJOB:
+        errno = 0;
+        id = strtoull(c->cmd + CMD_WAITJOB_LEN, &end_buf, 10);
+        if (errno) return reply_msg(c, MSG_BAD_FORMAT);
+        op_ct[type]++;
+
+        j = peek_job(id);
+
+        if (!j) return reply(c, MSG_NOTFOUND, MSG_NOTFOUND_LEN, STATE_SENDWORD);
+
+        wait_for_job_deleted(c, j);
+        /* process_queue(); */
+        break;
     case OP_PEEK_READY:
         /* don't allow trailing garbage */
         if (c->cmd_len != CMD_PEEK_READY_LEN + 2) {
@@ -1346,6 +1395,9 @@ dispatch_cmd(Conn *c)
 
         if (!j) return reply(c, MSG_NOTFOUND, MSG_NOTFOUND_LEN, STATE_SENDWORD);
 
+        if (j->waitjob_conn) {
+           notify_waiting_conns(j);
+        }
         j->tube->stat.total_delete_ct++;
 
         j->r.state = Invalid;

--- a/testserv.c
+++ b/testserv.c
@@ -357,7 +357,7 @@ void cttestcmdwaitjobdeleted()
        assert(nanoseconds() - start > 100000000); // 0.1s
     } else {
        fd = mustdiallocal(port);
-       usleep(100000);
+       usleep(110000); // 0.11s - pretend to spend time processing the job
        mustsend(fd, "reserve\r\n");
        ckresp(fd, "RESERVED 1 0\r\n");
        ckresp(fd, "\r\n");
@@ -392,13 +392,13 @@ void cttestcmdwaitjobparallel()
        mustsend(fd, "reserve\r\n");
        ckresp(fd, "RESERVED 1 0\r\n");
        ckresp(fd, "\r\n");
-       usleep(100000); // pretend to spend time processing the job
+       usleep(110000); // pretend to spend time processing the job
        mustsend(fd, "delete 1\r\n");
        ckresp(fd, "DELETED\r\n");
        mustsend(fd, "reserve\r\n");
        ckresp(fd, "RESERVED 2 0\r\n");
        ckresp(fd, "\r\n");
-       usleep(100000); // pretend to spend time processing the job
+       usleep(110000); // pretend to spend time processing the job
        mustsend(fd, "bury 2 0\r\n");
        ckresp(fd, "BURIED\r\n");
     }
@@ -421,7 +421,7 @@ void cttestcmdwaitjobburied()
        mustsend(fd, "reserve\r\n");
        ckresp(fd, "RESERVED 1 0\r\n");
        ckresp(fd, "\r\n");
-       usleep(100000);
+       usleep(110000); // pretend to spend time processing the job
        mustsend(fd, "bury 1 0\r\n");
        ckresp(fd, "BURIED\r\n");
     }

--- a/testserv.c
+++ b/testserv.c
@@ -15,6 +15,7 @@
 #include <fcntl.h>
 #include <sys/wait.h>
 #include <errno.h>
+#include <inttypes.h>
 #include "ct/ct.h"
 #include "dat.h"
 
@@ -381,11 +382,11 @@ void cttestcmdwaitjobparallel()
        mustsend(fd, "wait 2\r\n");
        ckresp(fd, "DELETED 1\r\n");
        int64 time = nanoseconds() - start;
-       assertf(time > 100000000, "%ld > 100000000", time); // 0.1s
+       assertf(time > 100000000, "%" PRId64 " > 100000000", time); // 0.1s
        start = nanoseconds();
        ckresp(fd, "BURIED 2\r\n");
        time = nanoseconds() - start;
-       assertf(time > 100000000, "%ld > 100000000", time); // 0.1s
+       assertf(time > 100000000, "%" PRId64 " > 100000000", time); // 0.1s
     } else {
        fd = mustdiallocal(port);
        mustsend(fd, "reserve\r\n");

--- a/testserv.c
+++ b/testserv.c
@@ -373,29 +373,31 @@ void cttestcmdwaitjobparallel()
        mustsend(fd, "put 0 0 0 0\r\n");
        mustsend(fd, "\r\n");
        ckresp(fd, "INSERTED 1\r\n");
+       int64 start = nanoseconds();
        mustsend(fd, "put 0 0 0 0\r\n");
        mustsend(fd, "\r\n");
        ckresp(fd, "INSERTED 2\r\n");
        mustsend(fd, "wait 1\r\n");
        mustsend(fd, "wait 2\r\n");
-       int64 start = nanoseconds();
        ckresp(fd, "DELETED 1\r\n");
-       assert(nanoseconds() - start > 100000000); // 0.1s
+       int64 time = nanoseconds() - start;
+       assertf(time > 100000000, "%ld > 100000000", time); // 0.1s
        start = nanoseconds();
        ckresp(fd, "BURIED 2\r\n");
-       assert(nanoseconds() - start > 100000000); // 0.1s
+       time = nanoseconds() - start;
+       assertf(time > 100000000, "%ld > 100000000", time); // 0.1s
     } else {
        fd = mustdiallocal(port);
-       usleep(100000);
        mustsend(fd, "reserve\r\n");
        ckresp(fd, "RESERVED 1 0\r\n");
        ckresp(fd, "\r\n");
+       usleep(100000); // pretend to spend time processing the job
        mustsend(fd, "delete 1\r\n");
        ckresp(fd, "DELETED\r\n");
        mustsend(fd, "reserve\r\n");
        ckresp(fd, "RESERVED 2 0\r\n");
        ckresp(fd, "\r\n");
-       usleep(100000);
+       usleep(100000); // pretend to spend time processing the job
        mustsend(fd, "bury 2 0\r\n");
        ckresp(fd, "BURIED\r\n");
     }

--- a/testserv.c
+++ b/testserv.c
@@ -342,6 +342,25 @@ cttestdeleteready()
     ckresp(fd, "DELETED\r\n");
 }
 
+void cttestcmdwaitjob()
+{
+    port = SERVER();
+    if (fork() > 0) {
+       fd = mustdiallocal(port);
+       mustsend(fd, "put 0 0 0 0\r\n");
+       mustsend(fd, "\r\n");
+       ckresp(fd, "INSERTED 1\r\n");
+       mustsend(fd, "wait 1\r\n");
+       int64 start = nanoseconds();
+       ckresp(fd, "WAITED 1\r\n");
+       assert(nanoseconds() - start > 100000000); // 0.1s
+    } else {
+       fd = mustdiallocal(port);
+       usleep(100000);
+       mustsend(fd, "delete 1\r\n");
+       ckresp(fd, "DELETED\r\n");
+    }
+}
 
 void
 cttestmultitube()

--- a/testserv.c
+++ b/testserv.c
@@ -350,15 +350,29 @@ void cttestcmdwaitjob()
        mustsend(fd, "put 0 0 0 0\r\n");
        mustsend(fd, "\r\n");
        ckresp(fd, "INSERTED 1\r\n");
+       mustsend(fd, "put 0 0 0 0\r\n");
+       mustsend(fd, "\r\n");
+       ckresp(fd, "INSERTED 2\r\n");
        mustsend(fd, "wait 1\r\n");
        int64 start = nanoseconds();
-       ckresp(fd, "WAITED 1\r\n");
+       ckresp(fd, "DELETED\r\n");
+       assert(nanoseconds() - start > 100000000); // 0.1s
+       mustsend(fd, "wait 2\r\n");
+       start = nanoseconds();
+       ckresp(fd, "BURIED\r\n");
        assert(nanoseconds() - start > 100000000); // 0.1s
     } else {
        fd = mustdiallocal(port);
        usleep(100000);
        mustsend(fd, "delete 1\r\n");
        ckresp(fd, "DELETED\r\n");
+       mustsend(fd, "reserve\r\n");
+       ckresp(fd, "RESERVED 2 0\r\n");
+       ckresp(fd, "\r\n");
+       usleep(100000);
+       mustsend(fd, "bury 2 0\r\n");
+       ckresp(fd, "BURIED\r\n");
+       exit(0);
     }
 }
 


### PR DESCRIPTION
Add a command: `wait <id>\r\n` that responds with `DELETED <id>\r\n` or `BURIED <id>\r\n` only once a job has been deleted or buried.

This allows a client to be notified about the status of a job without polling.
### From the docs

The wait command waits until a particular job is out of the system before responding. It can be used to block a client until a job is completed. It looks like this:

```
wait <id>\r\n
```
##### `wait` options
- `<id>` is the job id to wait for.
##### `wait` responses

The client expects one line of response once the state of the job has changed, which may be:
- `DELETED <id>\r\n` to indicate the job was deleted via the `delete` command (normal success).
- `BURIED <id>\r\n` to indicate the job was buried via the `bury` command.
- `NOT_FOUND\r\n` if the job id does not exist.

A response won't be sent by the server until the specified job is deleted or buried. The wait command can be issued multiple times before a response is received in order to wait on a collection of jobs.
