### PR TITLE
Tube names: add support for colons

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -17,6 +17,7 @@ Names only supports ASCII strings.
 * **hyphen** ("-")
 * **plus** ("+")
 * **slash** ("/")
+* **colon** (":")
 * **semicolon** (";")
 * **dot** (".")
 * **dollar-sign** ("$")

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -11,11 +11,11 @@ protocol are formatted in decimal and (unless otherwise indicated)
 nonnegative.
 
 Names, in this protocol, are ASCII strings. They may contain letters (A-Z and
-a-z), numerals (0-9), hyphen ("-"), plus ("+"), slash ("/"), semicolon (";"),
-dot ("."), dollar-sign ("$"), underscore ("_"), and parentheses ("(" and ")"),
-but they may not begin with a hyphen. They are terminated by white space
-(either a space char or end of line). Each name must be at least one character
-long.
+a-z), numerals (0-9), hyphen ("-"), plus ("+"), slash ("/"), colon (":"),
+semicolon (";"), dot ("."), dollar-sign ("$"), underscore ("_"), and
+parentheses ("(" and ")"), but they may not begin with a hyphen. They are
+terminated by white space (either a space char or end of line). Each name must
+be at least one character long.
 
 The protocol contains two kinds of data: text lines and unstructured chunks of
 data. Text lines are used for client commands and server responses. Chunks are

--- a/prot.c
+++ b/prot.c
@@ -21,7 +21,7 @@ size_t job_data_size_limit = JOB_DATA_SIZE_LIMIT_DEFAULT;
 #define NAME_CHARS \
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ" \
     "abcdefghijklmnopqrstuvwxyz" \
-    "0123456789-+/;.$_()"
+    "0123456789-+/;:.$_()"
 
 #define CMD_PUT "put "
 #define CMD_PEEKJOB "peek "


### PR DESCRIPTION
Not sure why they are limited at all except for \n\r\0
