### PR TITLE
Prevent Linux system suspend segfault, fixes #220

### DIFF
--- a/linux.c
+++ b/linux.c
@@ -79,7 +79,7 @@ socknext(Socket **s, int64 timeout)
         exit(1);
     }
 
-    if (r) {
+    if (r > 0) {
         *s = ev.data.ptr;
         if (ev.events & (EPOLLHUP|EPOLLRDHUP)) {
             return 'h';


### PR DESCRIPTION
A stab at fixing https://github.com/kr/beanstalkd/issues/220.

Prevents processing of epoll_wait error events. 

Previously epoll_event errors were implicitly ignored by the for loop that was used. However, the refactor (https://github.com/kr/beanstalkd/commit/e284badf079db519db8fdd2e86959f2ee17240be) swapped out the for loop for an if statement that simply verified the existence of an epoll_event response. This allowed epoll_events that returned -1 to be processed in the case that errno == EINT. Understandably, trying to process these events fails hard.

This change returns to the previous behavior of ignoring epoll_events <= 0.

I'm not sure what all would cause epoll_event to hit EINT, but this issue is broader than a system suspend issue and as such definitely warrants patching. It can be more easily duplicated by starting the daemon in the foreground and then backgrounding the daemon with CTRL-z. If you then try to bring it back to the foreground with `fg`, beanstalkd will segfault:

```
$ ./beanstalkd
^Z
[1]+  Stopped                 ./beanstalkd
$ fg
./beanstalkd
Segmentation fault (core dumped)
```

CT tests and others pass with this patch.
