### PR TITLE
IPV6_V6ONLY flag for NULL host

### DIFF
--- a/net.c
+++ b/net.c
@@ -98,6 +98,16 @@ make_server_socket(char *host, char *port)
         continue;
       }
 
+      if (NULL == host) {
+        flags = 0;
+        r = setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &flags, sizeof(flags));
+        if (r == -1) {
+          twarn("setting IPV6_V6ONLY off on fd %d", fd);
+          close(fd);
+          continue;
+        }
+      }
+
       if (verbose) {
           char hbuf[NI_MAXHOST], pbuf[NI_MAXSERV], *h = host, *p = port;
           r = getnameinfo(ai->ai_addr, ai->ai_addrlen,


### PR DESCRIPTION
The default listen for 0.0.0.0 does not actually listen on 0.0.0.0 on Fr...eeBSD (8.4 tested); it listens only on ::1.

This happens because the IPV6_V6ONLY flag has not been turned off.  It may default to off in Linux but on in FreeBSD, resulting in this not being discovered until now.

This is a simple patch that turns it off if a null host was passed in.

This really isn't the "right" thing to do either though;

I don't think getaddrinfo() and the resultant loop should be called at all in the case of a null host, but that's a bit too involved for me to get into right now.

This patch and commentary was sent to the beanstalkd mailing list on 12-Feb-2013 but has had no responses yet.
