### PR TITLE
Add draining mode status to the `stats` command

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -372,6 +372,8 @@ int  filewrjobfull(File*, job);
 
 
 #define Portdef "11300"
+#define Addrdef NULL
+#define Userdef NULL
 
 struct Server {
     char *port;

--- a/dat.h
+++ b/dat.h
@@ -380,7 +380,7 @@ struct Server {
     char *port;
     char *addr;
     char *user;
-    char *draining;
+    char *drain_mode;
 
     Wal    wal;
     Socket sock;

--- a/dat.h
+++ b/dat.h
@@ -374,11 +374,13 @@ int  filewrjobfull(File*, job);
 #define Portdef "11300"
 #define Addrdef NULL
 #define Userdef NULL
+#define Drainingdef "false"
 
 struct Server {
     char *port;
     char *addr;
     char *user;
+    char *draining;
 
     Wal    wal;
     Socket sock;

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -653,6 +653,9 @@ beanstalkd process starts; they are not stored on disk with the -b flag.
 
  - "hostname" the hostname of the machine as determined by uname.
 
+ - "draining" is "true" if the server has entered drain mode, "false"
+   otherwise.
+
 The list-tubes command returns a list of all existing tubes. Its form is:
 
 list-tubes\r\n

--- a/prot.c
+++ b/prot.c
@@ -886,7 +886,7 @@ fmt_stats(char *buf, size_t size, void *x)
 
     if (drain_mode)
     {
-        srv->draining = "true";
+        srv->drain_mode = "true";
     }
 
     getrusage(RUSAGE_SELF, &ru); /* don't care if it fails */
@@ -939,7 +939,7 @@ fmt_stats(char *buf, size_t size, void *x)
             srv->wal.filesize,
             id,
             node_info.nodename,
-            srv->draining);
+            srv->drain_mode);
 
 }
 

--- a/prot.c
+++ b/prot.c
@@ -187,6 +187,7 @@ size_t job_data_size_limit = JOB_DATA_SIZE_LIMIT_DEFAULT;
     "binlog-max-size: %d\n" \
     "id: %s\n" \
     "hostname: %s\n" \
+    "draining: %s\n" \
     "\r\n"
 
 #define STATS_TUBE_FMT "---\n" \
@@ -883,6 +884,11 @@ fmt_stats(char *buf, size_t size, void *x)
         wcur = srv->wal.cur->seq;
     }
 
+    if (drain_mode)
+    {
+        srv->draining = "true";
+    }
+
     getrusage(RUSAGE_SELF, &ru); /* don't care if it fails */
     return snprintf(buf, size, STATS_FMT,
             global_stat.urgent_ct,
@@ -932,7 +938,8 @@ fmt_stats(char *buf, size_t size, void *x)
             srv->wal.nrec,
             srv->wal.filesize,
             id,
-            node_info.nodename);
+            node_info.nodename,
+            srv->draining);
 
 }
 

--- a/serv.c
+++ b/serv.c
@@ -7,6 +7,7 @@ struct Server srv = {
     Portdef,
     Addrdef,
     Userdef,
+    Drainingdef,
     {
         Filesizedef,
     },

--- a/serv.c
+++ b/serv.c
@@ -5,8 +5,8 @@
 
 struct Server srv = {
     Portdef,
-    NULL,
-    NULL,
+    Addrdef,
+    Userdef,
     {
         Filesizedef,
     },


### PR DESCRIPTION
This supersedes, fixes

> The feature looks useful, but I think it would be more straightforward to put `draining: false` or `draining: true` in the output. This should be a 2-line change.

and closes #219. Had to create a separate pull request and not build on @justincase's because his repository didn't seem to exist anymore.

```
binlog-max-size: 10485760
id: 42cdbb04ec381e89
hostname: Mac.local
draining: false
```

```
$ kill -SIGUSR1 <pid>
```

```
binlog-max-size: 10485760
id: 42cdbb04ec381e89
hostname: Mac.local
draining: true
```
