### PR TITLE
Use ftruncate() as it's much more portable

### DIFF
--- a/linux.c
+++ b/linux.c
@@ -1,4 +1,6 @@
 #define _XOPEN_SOURCE 600
+#include <unistd.h>
+#include <sys/types.h>
 #include <stdint.h>
 #include <fcntl.h>
 #include <stdlib.h>
@@ -19,7 +21,7 @@ static int epfd;
 int
 rawfalloc(int fd, int len)
 {
-    return posix_fallocate(fd, 0, len);
+    return ftruncate(fd, len);
 }
 
 


### PR DESCRIPTION
Embedded systems (such as OpenWRT) often have reduced functionality; when operating in such circumstances, using the most widely available API's (or subsets of API's) is key for portability.  ftruncate() is much more ubiquitous than posix_fallocate().