### PR TITLE
Fix headers for MUSL compatibility

### DIFF
--- a/sd-daemon.c
+++ b/sd-daemon.c
@@ -32,7 +32,7 @@
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/un.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <netinet/in.h>
 #include <stdlib.h>
 #include <errno.h>


### PR DESCRIPTION
The MUSL headers generally don't like being included as <sys/foo.h> when the preferred means is <foo.h> (example: time.h) and will complain loudly when this happens.  It's unnecessary noise, and it
potentially draws attention from real warnings that might otherwise be overlooked.
