### PR TITLE
fix release script to allow releases

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 This is beanstalkd, a fast, general-purpose work queue.
-See http://kr.github.io/beanstalkd/ for general info.
+See https://beanstalkd.github.io/ for general info.
 
 Please note that this project is released with a Contributor
 Code of Conduct. By participating in this project you agree

--- a/doc/beanstalkd.1
+++ b/doc/beanstalkd.1
@@ -109,7 +109,7 @@ sd\-daemon(5), sd_listen_fds(5)
 Files \fBREADME\fR and \fBdoc/protocol\.txt\fR in the \fBbeanstalkd\fR distribution\.
 .
 .P
-\fIhttp://kr\.github\.com/beanstalkd/\fR
+\fIhttps://beanstalkd\.github\.io/\fR
 .
 .SH "AUTHOR"
 \fBBeanstalkd\fR is written and maintained by Keith Rarick with the help of many others\.

--- a/doc/beanstalkd.1.html
+++ b/doc/beanstalkd.1.html
@@ -157,7 +157,7 @@ details.</dd>
 <p>Files <code>README</code> and <code>doc/protocol.txt</code> in the <code>beanstalkd</code>
 distribution.</p>
 
-<p><a href="http://kr.github.com/beanstalkd/" data-bare-link="true">http://kr.github.com/beanstalkd/</a></p>
+<p><a href="https://beanstalkd.github.io/" data-bare-link="true">https://beanstalkd.github.io/</a></p>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 

--- a/doc/beanstalkd.ronn
+++ b/doc/beanstalkd.ronn
@@ -105,7 +105,7 @@ sd-daemon(5), sd_listen_fds(5)
 Files `README` and `doc/protocol.txt` in the `beanstalkd`
 distribution.
 
-<http://kr.github.com/beanstalkd/>
+<https://beanstalkd.github.io/>
 
 ## AUTHOR
 

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -1,0 +1,8 @@
+How to make a release:
+
+1. Check out master
+2. Tag the commit to release devX.Y: git tag dev1.11
+3. Write a change log in file News (don't commit it)
+4. Run pkg/dist.sh and follow the intructions.
+5. Push tags and beanstalkd.github.io
+6. Run pkg/mail.sh

--- a/pkg/Readme
+++ b/pkg/Readme
@@ -1,8 +1,0 @@
-How to make a release:
-
-1. Check out master
-2. Tag the commit to release devX.Y (e.g. dev1.9)
-3. Write a change log in file News (don't commit it)
-4. Run pkg/dist.sh
-5. Push tags and gh-pages
-6. Run pkg/mail.sh

--- a/pkg/bloghead.in
+++ b/pkg/bloghead.in
@@ -2,7 +2,7 @@
 layout: post
 title: Beanstalkd @VERSION@ Release Notes
 version: @VERSION@
-dist: https://github.com/kr/beanstalkd/archive/v@VERSION@.tar.gz
+dist: https://github.com/beanstalkd/beanstalkd/archive/v@VERSION@.tar.gz
 file: beanstalkd-@VERSION@.tar.gz
 ---
 

--- a/pkg/dist.sh
+++ b/pkg/dist.sh
@@ -41,12 +41,8 @@ tree=`git write-tree`
 commit=`git commit-tree $tree -p dev$ver -m "release $ver"`
 git tag -m "beanstalkd version $ver" v$ver $commit
 
-git rev-parse --verify gh-pages >/dev/null
-parent=`git rev-parse --verify gh-pages`
-git read-tree $parent
-postobj=`(exp <pkg/bloghead.in; git cat-file blob v$ver:News)|mkobj`
-post=_posts/`date +%Y-%m-%d`-$ver-release-notes.md
-git update-index --add --cacheinfo 100644 $postobj $post
-tree=`git write-tree`
-commit=`git commit-tree $tree -p $parent -m "announce release $ver"`
-git update-ref -m "commit: announce release $ver" refs/heads/gh-pages $commit $parent
+postcont=`(exp <pkg/bloghead.in; git cat-file blob v$ver:News)`
+postfile=`date +%Y-%m-%d`-$ver-release-notes.md
+echo "$postcont" >$postfile
+echo "Now, run these commands to update the blog:"
+echo "(mv $postfile ../beanstalkd.github.io/_posts/ && cd ../beanstalkd.github.io && git add . && git commit -m \"announce release $ver\")"

--- a/pkg/newstail.in
+++ b/pkg/newstail.in
@@ -1,21 +1,20 @@
-
-Full list of changes (includes authorship information):  
-<http://github.com/kr/beanstalkd/compare/v@PARENT@...v@VERSION@>
+Full list of changes (includes authorship information):
+<http://github.com/beanstalkd/beanstalkd/compare/v@PARENT@...v@VERSION@>
 
 Our Urls
 --------
 
-Download the @VERSION@ tarball directly:  
-<https://github.com/kr/beanstalkd/archive/v@VERSION@.tar.gz>
+Download the @VERSION@ tarball directly:
+<https://github.com/beanstalkd/beanstalkd/archive/v@VERSION@.tar.gz>
 
-Learn all about beanstalk:  
-<http://kr.github.com/beanstalkd/>
+Learn all about beanstalk:
+<https://beanstalkd.github.io/>
 
-Talk about beanstalk development or use at:  
-<http://groups.google.com/group/beanstalk-talk>
+Talk about beanstalk development or use at:
+<https://groups.google.com/group/beanstalk-talk>
 
 Bugs
 ----
 
-Please report any bugs to:  
-<http://github.com/kr/beanstalkd/issues>
+Please report any bugs to:
+<http://github.com/beanstalkd/beanstalkd/issues>


### PR DESCRIPTION
Since gh-page was moved into separate repository,
make the proccess of releasing semi-manual for website.

Fix links to the new site everywhere.