### PR TITLE
Enable code coverage on Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.gcda
+*.gcno
 *.o
 /vers.c
 /beanstalkd

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,12 @@ before_install:
 
 install:
     - |
+    # Currently works only with gcc on linux
       if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-          export LDFLAGS=" -lgcov --coverage"
-          export CFLAGS="-O0 -ggdb -fprofile-arcs -ftest-coverage"
-          export CXXFLAGS="-O0 -ggdb -fprofile-arcs -ftest-coverage"
+          if [[ "${TRAVIS_COMPILER} == "gcc" ]]; then
+              export LDFLAGS=" -lgcov --coverage"
+              export CFLAGS="-O0 -ggdb -fprofile-arcs -ftest-coverage"
+          fi
       fi
 
 script:
@@ -38,6 +40,14 @@ after_script:
 
 after_success:
     - |
-      if [ ! -z "${CODECOV_TOKEN}" ] && [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-          (bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports")
+      if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+          if [[ "${TRAVIS_COMPILER} == "gcc" ]]; then
+              curl -sSl https://codecov.io/bash -o "./codecov"
+              chmod +x codecov
+              ./codecov
+          else
+              echo "Skip collecting coverage reports for clang"
+          fi
+      else
+          echo "Skip coverage reports for OSX"
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,21 @@ os:
     - linux
     - osx
 
+env:
+    global:
+        - MAKEJOBS="-j$(getconf _NPROCESSORS_ONLN)"
+        - TRAVIS_COMMIT_LOG=`git log --format=fuller -2`
+
 before_install:
     - $CC --version
-    - export MAKEJOBS="-j$(getconf _NPROCESSORS_ONLN)"
-    - export TRAVIS_COMMIT_LOG=`git log --format=fuller -2`
+
+install:
+    - |
+      if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+          export LDFLAGS=" -lgcov --coverage"
+          export CFLAGS="-O0 -ggdb -fprofile-arcs -ftest-coverage"
+          export CXXFLAGS="-O0 -ggdb -fprofile-arcs -ftest-coverage"
+      fi
 
 script:
     - make $MAKEJOBS || ( echo "Build failure. Verbose build follows." && make V=1 ; false )
@@ -26,4 +37,7 @@ after_script:
     - printf "$TRAVIS_COMMIT_LOG\n"
 
 after_success:
-    - if [[ ! -z "${CODECOV_TOKEN}" ]]; then (bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"); fi;
+    - |
+      if [ ! -z "${CODECOV_TOKEN}" ] && [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+          (bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports")
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,38 +16,23 @@ env:
     global:
         - MAKEJOBS="-j$(getconf _NPROCESSORS_ONLN)"
         - TRAVIS_COMMIT_LOG=`git log --format=fuller -2`
+        - COVERAGE=OFF # Currently works only with gcc on linux
 
-before_install:
-    - $CC --version
-
-install:
-    - |
-    # Currently works only with gcc on linux
-      if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-          if [[ "${TRAVIS_COMPILER} == "gcc" ]]; then
-              export LDFLAGS=" -lgcov --coverage"
-              export CFLAGS="-O0 -ggdb -fprofile-arcs -ftest-coverage"
-          fi
-      fi
+before_script:
+    - if [ "${TRAVIS_OS_NAME}-${TRAVIS_COMPILER}" = "linux-gcc" ]; then export COVERAGE="ON"; fi
 
 script:
+    - |
+      if [ $COVERAGE = "ON" ]; then
+          export LDFLAGS=" -lgcov --coverage"
+          export CFLAGS="-O0 -ggdb -fprofile-arcs -ftest-coverage"
+      fi
     - make $MAKEJOBS || ( echo "Build failure. Verbose build follows." && make V=1 ; false )
     - make check $MAKEJOBS VERBOSE=1
+
+after_success:
+    - if [ $COVERAGE = "ON" ]; then (bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"); fi;
 
 after_script:
     - printf "$TRAVIS_COMMIT_RANGE\n"
     - printf "$TRAVIS_COMMIT_LOG\n"
-
-after_success:
-    - |
-      if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-          if [[ "${TRAVIS_COMPILER} == "gcc" ]]; then
-              curl -sSl https://codecov.io/bash -o "./codecov"
-              chmod +x codecov
-              ./codecov
-          else
-              echo "Skip collecting coverage reports for clang"
-          fi
-      else
-          echo "Skip coverage reports for OSX"
-      fi

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 PREFIX=/usr/local
 BINDIR=$(DESTDIR)$(PREFIX)/bin
-CFLAGS=-Wall -Werror\
-	-Wformat=2\
-	-g\
 
-LDFLAGS=
+override CFLAGS+=-Wall -Werror -Wformat=2 -g
+override LDFLAGS?=
+
 OS=$(shell uname|tr A-Z a-z)
 INSTALL=install
 
@@ -48,6 +47,8 @@ endif
 
 CLEANFILES=\
 	vers.c\
+	*.gcda\
+	*.gcno\
 
 .PHONY: all
 all: $(TARG)


### PR DESCRIPTION
I have no idea how to enable code coverage on OSX. Looks like we'll need `brew install lcov` or something like that:
```
clang  -lgcov --coverage  -o beanstalkd darwin.o conn.o file.o heap.o job.o ms.o net.o primes.o prot.o sd-daemon.o serv.o time.o tube.o util.o vers.o walg.o main.o 
ld: library not found for -lgcov
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [beanstalkd] Error 1
```

Another weird thing when use Clang on Linux:
```
./vers.gcno:version '402*', prefer '408*'
./vers.gcno:no functions found
./ct.gcno:version '402*', prefer '408*'

gcov: out of memory allocating 14955062000 bytes after a total of 135168 bytes
./_ctcheck.gcno:version '402*', prefer '408*'
./_ctcheck.gcno:no functions found
./file.gcno:version '402*', prefer '408*'

gcov: out of memory allocating 13612862216 bytes after a total of 135168 bytes
./testserv.gcno:version '402*', prefer '408*
...
...
...
```

So I enable it only for Linux and GCC for now. FYI: Current code coverage: 32.71%

Closes: #420, #396