### PR TITLE
add coverage badge and move license information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2007-2011 The Beanstalkd Authors.
+Copyright (c) 2007 The Beanstalkd Authors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,7 @@
-Copyright (c) 2007 The Beanstalkd Authors.
+Copyright (c) 2007 The authors of beanstalkd.
+
+Copyright in contributions to beanstalkd is retained
+by the original copyright holder of each contribution.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -49,12 +49,3 @@ information on how to write them.
 [![Build Status](https://travis-ci.org/beanstalkd/beanstalkd.svg?branch=master)](https://travis-ci.org/beanstalkd/beanstalkd)
 [![codecov](https://codecov.io/gh/beanstalkd/beanstalkd/branch/master/graph/badge.svg)](https://codecov.io/gh/beanstalkd/beanstalkd)
 
-## License
-
-beanstalkd is released under the [MIT License](https://opensource.org/licenses/MIT).
-
-Copyright © 2007 The authors of beanstalkd.
-
-Copyright in contributions to beanstalkd is retained
-by the original copyright holder of each contribution.
-See file LICENSE for terms of use.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Please note that this project is released with a Contributor
 Code of Conduct. By participating in this project you agree
 to abide by its terms. See CodeOfConduct.txt for details.
 
-[![Build Status](https://travis-ci.org/beanstalkd/beanstalkd.svg?branch=master)](https://travis-ci.org/beanstalkd/beanstalkd)
-
 ## Quick Start
 
     $ make
@@ -47,8 +45,16 @@ See http://github.com/rtomayko/ronn.
 Unit tests are in test*.c. See https://github.com/kr/ct for
 information on how to write them.
 
+## Code Status
+[![Build Status](https://travis-ci.org/beanstalkd/beanstalkd.svg?branch=master)](https://travis-ci.org/beanstalkd/beanstalkd)
+[![codecov](https://codecov.io/gh/beanstalkd/beanstalkd/branch/master/graph/badge.svg)](https://codecov.io/gh/beanstalkd/beanstalkd)
 
-Copyright © 2007-2019 the authors of beanstalkd.
+## License
+
+beanstalkd is released under the [MIT License](https://opensource.org/licenses/MIT).
+
+Copyright © 2007 The authors of beanstalkd.
+
 Copyright in contributions to beanstalkd is retained
 by the original copyright holder of each contribution.
 See file LICENSE for terms of use.


### PR DESCRIPTION
Add coverage badge and move license and copyright to the LICENSE file.

Updates #396 