### PR TITLE
Improved code coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ git:
 
 language: c
 
+addons:
+    apt:
+      packages:
+          - lcov
+
 compiler:
     - clang
     - gcc
@@ -28,6 +33,26 @@ script:
           export CFLAGS="-O0 -ggdb -fprofile-arcs -ftest-coverage"
       fi
     - make $MAKEJOBS || ( echo "Build failure. Verbose build follows." && make V=1 ; false )
+    - |
+      if [ $COVERAGE = "ON" ]; then
+          # Reset all execution counts to zero
+          lcov \
+              --quiet \
+              --directory . \
+              --base-directory=$(pwd) \
+              --compat-libtool \
+              --zerocounters
+
+         # Capture coverage data
+         lcov \
+             --quiet \
+              --directory . \
+              --base-directory=$(pwd) \
+              --capture \
+              --initial \
+              --compat-libtool \
+              --output-file $(pwd)/lcov.info
+      fi
     - make check -j1 VERBOSE=1
 
 jobs:
@@ -50,7 +75,36 @@ jobs:
           - make $MAKEJOBS bench
 
 after_success:
-    - if [ $COVERAGE = "ON" ]; then (bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"); fi;
+    - |
+      if [ $COVERAGE = "ON" ]; then
+          # Capture coverage data
+          lcov \
+              --quiet \
+              --directory . \
+              --base-directory=$(pwd) \
+              --no-checksum \
+              --capture \
+              --compat-libtool \
+              --output-file $(pwd)/lcov.info
+
+          # Remove files matching exclude patterns
+          lcov \
+              --quiet \
+              --remove $(pwd)/lcov.info "ct/*" \
+              --remove $(pwd)/lcov.info "adm/*" \
+              --remove $(pwd)/lcov.info "pkg/*" \
+              --remove $(pwd)/lcov.info "testheap.c" \
+              --remove $(pwd)/lcov.info "testjobs.c" \
+              --remove $(pwd)/lcov.info "testserv.c" \
+              --remove $(pwd)/lcov.info "testutil.c" \
+              --compat-libtool \
+              --output-file $(pwd)/lcov.info
+
+          # Run codecov
+          curl -sSl https://codecov.io/bash -o ./codecov
+          chmod +x ./codecov
+          ./codecov -f $(pwd)/lcov.info
+      fi
 
 after_script:
     - printf "$TRAVIS_COMMIT_RANGE\n"


### PR DESCRIPTION
Remove files and directories from coverage report matching exclude patterns:
- `ct/*`
- `adm/*`
- `pkg/*`
- `testheap.c`
- `testjobs.c`
- `testserv.c`
- `testutil.c`

I have no idea why, but ignoring via `codecov.yml` does not work.

Refs: #424