### PR TITLE
fix tests names for more readable ones

### DIFF
--- a/testheap.c
+++ b/testheap.c
@@ -8,7 +8,7 @@
 
 
 void
-cttestheap_insert_one()
+cttest_heap_insert_one()
 {
     Heap h = {0};
     job j;
@@ -24,9 +24,8 @@ cttestheap_insert_one()
     assertf(j->heap_index == 0, "should match");
 }
 
-
 void
-cttestheap_insert_and_remove_one()
+cttest_heap_insert_and_remove_one()
 {
     Heap h = {0};
     int r;
@@ -47,9 +46,8 @@ cttestheap_insert_and_remove_one()
     assertf(j->heap_index == -1, "j's heap index should be invalid");
 }
 
-
 void
-cttestheap_priority()
+cttest_heap_priority()
 {
     Heap h = {0};
     int r;
@@ -92,9 +90,8 @@ cttestheap_priority()
     assertf(j == j3, "j3 should come out third.");
 }
 
-
 void
-cttestheap_fifo_property()
+cttest_heap_fifo_property()
 {
     Heap h = {0};
     int r;
@@ -140,9 +137,8 @@ cttestheap_fifo_property()
     assertf(j == j3c, "j3c should come out third.");
 }
 
-
 void
-cttestheap_many_jobs()
+cttest_heap_many_jobs()
 {
     Heap h = {0};
     uint last_pri;
@@ -167,9 +163,8 @@ cttestheap_many_jobs()
     }
 }
 
-
 void
-cttestheap_remove_k()
+cttest_heap_remove_k()
 {
     Heap h = {0};
     uint last_pri;
@@ -201,7 +196,7 @@ cttestheap_remove_k()
 }
 
 void
-ctbenchheapinsert(int n)
+ctbench_heap_insert(int n)
 {
     job *j;
     int i;
@@ -222,7 +217,7 @@ ctbenchheapinsert(int n)
 }
 
 void
-ctbenchheapremove(int n)
+ctbench_heap_remove(int n)
 {
     Heap h = {0};
     job j;

--- a/testjobs.c
+++ b/testjobs.c
@@ -9,7 +9,7 @@
 static tube default_tube;
 
 void
-cttestjob_creation()
+cttest_job_creation()
 {
     job j;
 
@@ -19,7 +19,7 @@ cttestjob_creation()
 }
 
 void
-cttestjob_cmp_pris()
+cttest_job_cmp_pris()
 {
     job a, b;
 
@@ -31,7 +31,7 @@ cttestjob_cmp_pris()
 }
 
 void
-cttestjob_cmp_ids()
+cttest_job_cmp_ids()
 {
     job a, b;
 
@@ -43,9 +43,8 @@ cttestjob_cmp_ids()
     assertf(job_pri_less(a, b), "should be less");
 }
 
-
 void
-cttestjob_large_pris()
+cttest_job_large_pris()
 {
     job a, b;
 
@@ -62,7 +61,7 @@ cttestjob_large_pris()
 }
 
 void
-cttestjob_hash_free()
+cttest_job_hash_free()
 {
     job j;
     uint64 jid = 83;
@@ -75,7 +74,7 @@ cttestjob_hash_free()
 }
 
 void
-cttestjob_hash_free_next()
+cttest_job_hash_free_next()
 {
     job a, b;
     uint64 aid = 97, bid = 12386;
@@ -92,7 +91,7 @@ cttestjob_hash_free_next()
 }
 
 void
-cttestjob_all_jobs_used()
+cttest_job_all_jobs_used()
 {
     job j, x;
 
@@ -111,7 +110,7 @@ cttestjob_all_jobs_used()
 }
 
 void
-cttestjob_100_000_jobs()
+cttest_job_100_000_jobs()
 {
     int i;
 
@@ -129,7 +128,7 @@ cttestjob_100_000_jobs()
 }
 
 void
-ctbenchmakejob(int n)
+ctbench_make_job(int n)
 {
     int i;
     TUBE_ASSIGN(default_tube, make_tube("default"));

--- a/testserv.c
+++ b/testserv.c
@@ -36,7 +36,6 @@ wrapfalloc(int fd, int size)
     return rawfalloc(fd, size);
 }
 
-
 static void
 muststart(char *a0, char *a1, char *a2, char *a3, char *a4)
 {
@@ -57,7 +56,6 @@ muststart(char *a0, char *a1, char *a2, char *a3, char *a4)
 
     execlp(a0, a0, a1, a2, a3, a4, NULL);
 }
-
 
 static int
 mustdiallocal(int port)
@@ -80,7 +78,7 @@ mustdiallocal(int port)
         exit(1);
     }
 
-    r = connect(fd, (struct sockaddr*)&addr, sizeof addr);
+    r = connect(fd, (struct sockaddr *)&addr, sizeof addr);
     if (r == -1) {
         twarn("connect");
         exit(1);
@@ -89,8 +87,7 @@ mustdiallocal(int port)
     return fd;
 }
 
-
-#define SERVER() (progname=__func__, mustforksrv())
+#define SERVER() (progname = __func__, mustforksrv())
 
 static int
 mustforksrv()
@@ -105,7 +102,7 @@ mustforksrv()
     }
 
     len = sizeof(addr);
-    r = getsockname(srv.sock.fd, (struct sockaddr*)&addr, (socklen_t*)&len);
+    r = getsockname(srv.sock.fd, (struct sockaddr *)&addr, (socklen_t *)&len);
     if (r == -1 || len > sizeof(addr)) {
         puts("mustforksrv failed");
         exit(1);
@@ -149,7 +146,6 @@ mustforksrv()
     srvserve(&srv); /* does not return */
     exit(1); /* satisfy the compiler */
 }
-
 
 static char *
 readline(int fd)
@@ -203,7 +199,6 @@ readline(int fd)
     return buf;
 }
 
-
 static void
 ckresp(int fd, char *exp)
 {
@@ -213,7 +208,6 @@ ckresp(int fd, char *exp)
     assertf(strcmp(exp, line) == 0, "\"%s\" != \"%s\"", exp, line);
 }
 
-
 static void
 ckrespsub(int fd, char *sub)
 {
@@ -222,7 +216,6 @@ ckrespsub(int fd, char *sub)
     line = readline(fd);
     assertf(strstr(line, sub), "\"%s\" not in \"%s\"", sub, line);
 }
-
 
 static void
 writefull(int fd, char *s, int n)
@@ -238,7 +231,6 @@ writefull(int fd, char *s, int n)
     }
 }
 
-
 static void
 mustsend(int fd, char *s)
 {
@@ -246,7 +238,6 @@ mustsend(int fd, char *s)
     printf(">%d %s", fd, s);
     fflush(stdout);
 }
-
 
 static int
 filesize(char *path)
@@ -262,7 +253,6 @@ filesize(char *path)
     return s.st_size;
 }
 
-
 static int
 exist(char *path)
 {
@@ -273,9 +263,8 @@ exist(char *path)
     return r != -1;
 }
 
-
 void
-cttestpause()
+cttest_pause()
 {
     int64 s;
 
@@ -293,9 +282,8 @@ cttestpause()
     assert(nanoseconds() - s >= 1000000000); // 1s
 }
 
-
 void
-cttestunderscore()
+cttest_underscore()
 {
     port = SERVER();
     fd = mustdiallocal(port);
@@ -303,9 +291,8 @@ cttestunderscore()
     ckresp(fd, "USING x_y\r\n");
 }
 
-
 void
-cttest2cmdpacket()
+cttest_2cmdpacket()
 {
     port = SERVER();
     fd = mustdiallocal(port);
@@ -314,9 +301,8 @@ cttest2cmdpacket()
     ckresp(fd, "USING b\r\n");
 }
 
-
 void
-cttesttoobig()
+cttest_too_big()
 {
     job_data_size_limit = 10;
     port = SERVER();
@@ -329,9 +315,8 @@ cttesttoobig()
     ckresp(fd, "INSERTED 1\r\n");
 }
 
-
 void
-cttestdeleteready()
+cttest_delete_ready()
 {
     port = SERVER();
     fd = mustdiallocal(port);
@@ -342,9 +327,8 @@ cttestdeleteready()
     ckresp(fd, "DELETED\r\n");
 }
 
-
 void
-cttestmultitube()
+cttest_multi_tube()
 {
     port = SERVER();
     fd = mustdiallocal(port);
@@ -366,9 +350,8 @@ cttestmultitube()
     ckresp(fd, "RESERVED 2 0\r\n");
 }
 
-
 void
-cttestnonegativedelay()
+cttest_negative_delay()
 {
     port = SERVER();
     fd = mustdiallocal(port);
@@ -376,9 +359,8 @@ cttestnonegativedelay()
     ckresp(fd, "BAD_FORMAT\r\n");
 }
 
-
 void
-cttestomittimeleft()
+cttest_omit_time_left()
 {
     port = SERVER();
     fd = mustdiallocal(port);
@@ -390,9 +372,8 @@ cttestomittimeleft()
     ckrespsub(fd, "\ntime-left: 0\n");
 }
 
-
 void
-cttestsmalldelay()
+cttest_small_delay()
 {
     port = SERVER();
     fd = mustdiallocal(port);
@@ -401,9 +382,8 @@ cttestsmalldelay()
     ckresp(fd, "INSERTED 1\r\n");
 }
 
-
 void
-ctteststatstube()
+cttest_stats_tube()
 {
     port = SERVER();
     fd = mustdiallocal(port);
@@ -502,9 +482,8 @@ ctteststatstube()
     ckrespsub(fd, "\npause-time-left: 0\n");
 }
 
-
 void
-cttestttrlarge()
+cttest_ttrlarge()
 {
     port = SERVER();
     fd = mustdiallocal(port);
@@ -552,9 +531,8 @@ cttestttrlarge()
     ckrespsub(fd, "\nttr: 21600\n");
 }
 
-
 void
-cttestttrsmall()
+cttest_ttr_small()
 {
     port = SERVER();
     fd = mustdiallocal(port);
@@ -566,9 +544,8 @@ cttestttrsmall()
     ckrespsub(fd, "\nttr: 1\n");
 }
 
-
 void
-cttestzerodelay()
+cttest_zero_delay()
 {
     port = SERVER();
     fd = mustdiallocal(port);
@@ -577,9 +554,8 @@ cttestzerodelay()
     ckresp(fd, "INSERTED 1\r\n");
 }
 
-
 void
-cttestreservewithtimeout2conn()
+cttest_reserve_with_timeout_2conns()
 {
     int fd0, fd1;
 
@@ -597,9 +573,8 @@ cttestreservewithtimeout2conn()
     ckresp(fd0, "TIMED_OUT\r\n");
 }
 
-
 void
-cttestunpausetube()
+cttest_unpause_tube()
 {
     int fd0, fd1;
 
@@ -625,9 +600,8 @@ cttestunpausetube()
     ckresp(fd1, "\r\n");
 }
 
-
 void
-cttestbinlogemptyexit()
+cttest_binlog_empty_exit()
 {
     srv.wal.dir = ctdir();
     srv.wal.use = 1;
@@ -645,9 +619,8 @@ cttestbinlogemptyexit()
     ckresp(fd, "INSERTED 1\r\n");
 }
 
-
 void
-cttestbinlogbury()
+cttest_binlog_bury()
 {
     srv.wal.dir = ctdir();
     srv.wal.use = 1;
@@ -665,9 +638,8 @@ cttestbinlogbury()
     ckresp(fd, "BURIED\r\n");
 }
 
-
 void
-cttestbinlogbasic()
+cttest_binlog_basic()
 {
     srv.wal.dir = ctdir();
     srv.wal.use = 1;
@@ -688,9 +660,8 @@ cttestbinlogbasic()
     ckresp(fd, "DELETED\r\n");
 }
 
-
 void
-cttestbinlogsizelimit()
+cttest_binlog_size_limit()
 {
     int i = 0;
     char *b2;
@@ -718,9 +689,8 @@ cttestbinlogsizelimit()
     assertf(gotsize == size, "binlog.2 %d != %d", gotsize, size);
 }
 
-
 void
-cttestbinlogallocation()
+cttest_binlog_allocation()
 {
     int i = 0;
 
@@ -744,9 +714,8 @@ cttestbinlogallocation()
     }
 }
 
-
 void
-cttestbinlogread()
+cttest_binlog_read()
 {
     srv.wal.dir = ctdir();
     srv.wal.use = 1;
@@ -792,9 +761,8 @@ cttestbinlogread()
     ckresp(fd, "NOT_FOUND\r\n");
 }
 
-
 void
-cttestbinlogdiskfull()
+cttest_binlog_disk_full()
 {
     size = 1000;
     falloc = &wrapfalloc;
@@ -857,9 +825,8 @@ cttestbinlogdiskfull()
     ckresp(fd, "DELETED\r\n");
 }
 
-
 void
-cttestbinlogdiskfulldelete()
+cttest_binlog_disk_full_delete()
 {
     size = 1000;
     falloc = &wrapfalloc;
@@ -924,9 +891,8 @@ cttestbinlogdiskfulldelete()
     ckresp(fd, "DELETED\r\n");
 }
 
-
 void
-cttestbinlogv5()
+cttest_binlog_v5()
 {
     char portstr[10];
 
@@ -935,8 +901,8 @@ cttestbinlogv5()
         exit(0);
     }
 
-    progname=__func__;
-    port = (rand()&0xfbff) + 1024;
+    progname = __func__;
+    port = (rand() & 0xfbff) + 1024;
     sprintf(portstr, "%d", port);
     muststart("beanstalkd-1.4.6", "-b", ctdir(), "-p", portstr);
     fd = mustdiallocal(port);
@@ -1097,9 +1063,8 @@ cttestbinlogv5()
     ckrespsub(fd, "\nkicks: 0\n");
 }
 
-
 static void
-benchputdeletesize(int n, int size)
+bench_put_delete_size(int n, int size)
 {
     port = SERVER();
     fd = mustdiallocal(port);
@@ -1115,29 +1080,32 @@ benchputdeletesize(int n, int size)
         mustsend(fd, body);
         mustsend(fd, "\r\n");
         ckrespsub(fd, "INSERTED ");
-        sprintf(buf, "delete %d\r\n", i+1);
+        sprintf(buf, "delete %d\r\n", i + 1);
         mustsend(fd, buf);
         ckresp(fd, "DELETED\r\n");
     }
 }
 
-
 void
-ctbenchputdelete8byte(int n)
+ctbench_put_delete_8(int n)
 {
-    benchputdeletesize(n, 8);
+    bench_put_delete_size(n, 8);
 }
 
-
 void
-ctbenchputdelete1k(int n)
+ctbench_put_delete_1k(int n)
 {
-    benchputdeletesize(n, 1024);
+    bench_put_delete_size(n, 1024);
 }
 
+void
+ctbench_put_delete_8k(int n)
+{
+    bench_put_delete_size(n, 8192);
+}
 
 void
-ctbenchputdelete8k(int n)
+ctbench_put_delete_64k(int n)
 {
-    benchputdeletesize(n, 8192);
+    bench_put_delete_size(n, 65535);
 }

--- a/testutil.c
+++ b/testutil.c
@@ -8,7 +8,7 @@
 #include "dat.h"
 
 void
-cttestallocf()
+cttest_allocf()
 {
     char *got;
 
@@ -16,9 +16,8 @@ cttestallocf()
     assertf(strcmp("hello, world 5", got) == 0, "got \"%s\"", got);
 }
 
-
 void
-cttestoptnone()
+cttest_opt_none()
 {
     char *args[] = {
         NULL,
@@ -37,16 +36,14 @@ cttestoptnone()
     assert(verbose == 0);
 }
 
-
 static void
 success(void)
 {
     _exit(0);
 }
 
-
 void
-cttestoptminus()
+cttest_optminus()
 {
     char *args[] = {
         "-",
@@ -58,9 +55,8 @@ cttestoptminus()
     assertf(0, "optparse failed to call exit");
 }
 
-
 void
-cttestoptp()
+cttest_optp()
 {
     char *args[] = {
         "-p1234",
@@ -71,9 +67,8 @@ cttestoptp()
     assert(strcmp(srv.port, "1234") == 0);
 }
 
-
 void
-cttestoptl()
+cttest_optl()
 {
     char *args[] = {
         "-llocalhost",
@@ -84,9 +79,8 @@ cttestoptl()
     assert(strcmp(srv.addr, "localhost") == 0);
 }
 
-
 void
-cttestoptlseparate()
+cttest_optlseparate()
 {
     char *args[] = {
         "-l",
@@ -98,9 +92,8 @@ cttestoptlseparate()
     assert(strcmp(srv.addr, "localhost") == 0);
 }
 
-
 void
-cttestoptz()
+cttest_optz()
 {
     char *args[] = {
         "-z1234",
@@ -111,9 +104,8 @@ cttestoptz()
     assert(job_data_size_limit == 1234);
 }
 
-
 void
-cttestopts()
+cttest_opts()
 {
     char *args[] = {
         "-s1234",
@@ -124,9 +116,8 @@ cttestopts()
     assert(srv.wal.filesize == 1234);
 }
 
-
 void
-cttestoptc()
+cttest_optc()
 {
     char *args[] = {
         "-n",
@@ -138,9 +129,8 @@ cttestoptc()
     assert(srv.wal.nocomp == 0);
 }
 
-
 void
-cttestoptn()
+cttest_optn()
 {
     char *args[] = {
         "-n",
@@ -151,9 +141,8 @@ cttestoptn()
     assert(srv.wal.nocomp == 1);
 }
 
-
 void
-cttestoptf()
+cttest_optf()
 {
     char *args[] = {
         "-f1234",
@@ -165,9 +154,8 @@ cttestoptf()
     assert(srv.wal.wantsync == 1);
 }
 
-
 void
-cttestoptF()
+cttest_optF()
 {
     char *args[] = {
         "-f1234",
@@ -179,9 +167,8 @@ cttestoptF()
     assert(srv.wal.wantsync == 0);
 }
 
-
 void
-cttestoptu()
+cttest_optu()
 {
     char *args[] = {
         "-ukr",
@@ -192,9 +179,8 @@ cttestoptu()
     assert(strcmp(srv.user, "kr") == 0);
 }
 
-
 void
-cttestoptb()
+cttest_optb()
 {
     char *args[] = {
         "-bfoo",
@@ -206,9 +192,8 @@ cttestoptb()
     assert(srv.wal.use == 1);
 }
 
-
 void
-cttestoptV()
+cttest_optV()
 {
     char *args[] = {
         "-V",
@@ -219,9 +204,8 @@ cttestoptV()
     assert(verbose == 1);
 }
 
-
 void
-cttestoptV_V()
+cttest_optV_V()
 {
     char *args[] = {
         "-V",
@@ -233,9 +217,8 @@ cttestoptV_V()
     assert(verbose == 2);
 }
 
-
 void
-cttestoptVVV()
+cttest_optVVV()
 {
     char *args[] = {
         "-VVV",
@@ -246,9 +229,8 @@ cttestoptVVV()
     assert(verbose == 3);
 }
 
-
 void
-cttestoptVnVu()
+cttest_optVnVu()
 {
     char *args[] = {
         "-VnVukr",


### PR DESCRIPTION
All tests functions are more readble since
word are separated with underscores.
Redundant newlines are removed.

Fixes #441