### PR TITLE
fix types to satisfy -Wextra

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -274,9 +274,9 @@ struct Conn {
     int    pending_timeout;
     char   halfclosed;
 
-    char cmd[LINE_BUF_SIZE]; // this string is NOT NUL-terminated
-    int  cmd_len;
-    int  cmd_read;
+    char   cmd[LINE_BUF_SIZE]; // this string is NOT NUL-terminated
+    size_t cmd_len;
+    int    cmd_read;
 
     char *reply;
     int  reply_len;

--- a/file.c
+++ b/file.c
@@ -201,7 +201,7 @@ readrec(File *f, job l, int *err)
     case Buried:
     case Delayed:
         if (!j) {
-            if (jr.body_size > job_data_size_limit) {
+            if ((size_t)jr.body_size > job_data_size_limit) {
                 warnpos(f, -r, "job %"PRIu64" is too big (%"PRId32" > %zu)",
                         jr.id,
                         jr.body_size,
@@ -325,7 +325,7 @@ readrec5(File *f, job l, int *err)
     case Buried:
     case Delayed:
         if (!j) {
-            if (jr.body_size > job_data_size_limit) {
+            if ((size_t)jr.body_size > job_data_size_limit) {
                 warnpos(f, -r, "job %"PRIu64" is too big (%"PRId32" > %zu)",
                         jr.id,
                         jr.body_size,
@@ -460,7 +460,7 @@ filewopen(File *f)
     }
 
     n = write(fd, &ver, sizeof(int));
-    if (n < sizeof(int)) {
+    if (n < 0 || (size_t)n < sizeof(int)) {
         twarn("write %s", f->path);
         close(fd);
         return;


### PR DESCRIPTION
There is lot of work to be done to satisfy -Wextra.
This is the first step where I have eliminated all
errors related to the non-strict type coercion.

Reduced the scope of some variables.

While at it I have eliminated function "one_cmd" as making
code more complex that it has to be.