### PR TITLE
set input width of pri, delay and ttr params to uint32

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -57,6 +57,9 @@ typedef int(FAlloc)(int, int);
 #define URGENT_THRESHOLD 1024
 #define JOB_DATA_SIZE_LIMIT_DEFAULT ((1 << 16) - 1)
 
+/* Maximum value (uint32) allowed in pri, delay and ttr parameters */
+#define MAX_UINT32 4294967295
+
 extern const char version[];
 extern int verbose;
 extern struct Server srv;

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -135,13 +135,14 @@ below).
 
  - <delay> is an integer number of seconds to wait before putting the job in
    the ready queue. The job will be in the "delayed" state during this time.
+   Maximum delay is 2**32-1.
 
  - <ttr> -- time to run -- is an integer number of seconds to allow a worker
    to run this job. This time is counted from the moment a worker reserves
    this job. If the worker does not delete, release, or bury the job within
    <ttr> seconds, the job will time out and the server will release the job.
    The minimum ttr is 1. If the client sends 0, the server will silently
-   increase the ttr to 1.
+   increase the ttr to 1. Maximum ttr is 2**32-1.
 
  - <bytes> is an integer indicating the size of the job body, not including the
    trailing "\r\n". This value must be less than max-job-size (default: 2**16).

--- a/job.c
+++ b/job.c
@@ -105,7 +105,7 @@ allocate_job(int body_size)
 }
 
 job
-make_job_with_id(uint pri, int64 delay, int64 ttr,
+make_job_with_id(uint32 pri, int64 delay, int64 ttr,
                  int body_size, tube tube, uint64 id)
 {
     job j;

--- a/testserv.c
+++ b/testserv.c
@@ -264,6 +264,27 @@ exist(char *path)
 }
 
 void
+cttest_unknown_command()
+{
+    port = SERVER();
+    fd = mustdiallocal(port);
+    mustsend(fd, "nont10knowncommand\r\n");
+    ckresp(fd, "UNKNOWN_COMMAND\r\n");
+}
+
+void
+cttest_too_long_commandline()
+{
+    port = SERVER();
+    fd = mustdiallocal(port);
+    int i;
+    for (i = 0; i < 5; i++)
+        mustsend(fd, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    mustsend(fd, "\r\n");
+    ckresp(fd, "BAD_FORMAT\r\n");
+}
+
+void
 cttest_pause()
 {
     int64 s;
@@ -356,6 +377,48 @@ cttest_negative_delay()
     port = SERVER();
     fd = mustdiallocal(port);
     mustsend(fd, "put 512 -1 100 0\r\n");
+    ckresp(fd, "BAD_FORMAT\r\n");
+}
+
+/* TODO: add more edge cases tests for delay and ttr */
+
+void
+cttest_garbage_priority()
+{
+    port = SERVER();
+    fd = mustdiallocal(port);
+    mustsend(fd, "put -1kkdj9djjkd9 0 100 1\r\n");
+    mustsend(fd, "a\r\n");
+    ckresp(fd, "BAD_FORMAT\r\n");
+}
+
+void
+cttest_negative_priority()
+{
+    port = SERVER();
+    fd = mustdiallocal(port);
+    mustsend(fd, "put -1 0 100 1\r\n");
+    mustsend(fd, "a\r\n");
+    ckresp(fd, "BAD_FORMAT\r\n");
+}
+
+void
+cttest_max_priority()
+{
+    port = SERVER();
+    fd = mustdiallocal(port);
+    mustsend(fd, "put 4294967295 0 100 1\r\n");
+    mustsend(fd, "a\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
+}
+
+void
+cttest_too_big_priority()
+{
+    port = SERVER();
+    fd = mustdiallocal(port);
+    mustsend(fd, "put 4294967296 0 100 1\r\n");
+    mustsend(fd, "a\r\n");
     ckresp(fd, "BAD_FORMAT\r\n");
 }
 


### PR DESCRIPTION
Before this fix if the value specified in
pri/delay/ttr parameters would equal to 2**32
then it would be messed up and set to zero because of overflow.
And in general, the behaviour was not defined strictly
because the uint type can take different width.

I have fixed the read_num function to parse integer
that fits into range 0 .. 2**32-1. Internally it parses
integer into uint64, but it checks if it fits into uint32.
So it will return success only in this case.

I have added multiple tests checking that behaviour.

Fixes #230