### PR TITLE
build master on travis-ci after each merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+    only:
+        - master
+
 git:
     quiet: true
     depth: 5


### PR DESCRIPTION
This prevented codecov from showing correct coverage diff because
the base (master) was not ever built after the merge.