### PR TITLE
mark unused parameters to satisfy -Wextra

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -16,6 +16,8 @@ int verbose = 0;
 static void
 on_watch(ms a, tube t, size_t i)
 {
+    UNUSED_PARAMETER(a);
+    UNUSED_PARAMETER(i);
     tube_iref(t);
     t->watching_ct++;
 }
@@ -23,6 +25,8 @@ on_watch(ms a, tube t, size_t i)
 static void
 on_ignore(ms a, tube t, size_t i)
 {
+    UNUSED_PARAMETER(a);
+    UNUSED_PARAMETER(i);
     t->watching_ct--;
     tube_dref(t);
 }

--- a/dat.h
+++ b/dat.h
@@ -60,6 +60,8 @@ typedef int(FAlloc)(int, int);
 /* Maximum value (uint32) allowed in pri, delay and ttr parameters */
 #define MAX_UINT32 4294967295
 
+#define UNUSED_PARAMETER(x) (void)(x)
+
 extern const char version[];
 extern int verbose;
 extern struct Server srv;

--- a/main.c
+++ b/main.c
@@ -12,11 +12,8 @@
 static void
 su(const char *user) 
 {
-    int r;
-    struct passwd *pwent;
-
     errno = 0;
-    pwent = getpwnam(user);
+    struct passwd *pwent = getpwnam(user);
     if (errno) {
         twarn("getpwnam(\"%s\")", user);
         exit(32);
@@ -26,7 +23,7 @@ su(const char *user)
         exit(33);
     }
 
-    r = setgid(pwent->pw_gid);
+    int r = setgid(pwent->pw_gid);
     if (r == -1) {
         twarn("setgid(%d \"%s\")", pwent->pw_gid, user);
         exit(34);
@@ -43,12 +40,11 @@ su(const char *user)
 static void
 set_sig_handlers()
 {
-    int r;
     struct sigaction sa;
 
     sa.sa_handler = SIG_IGN;
     sa.sa_flags = 0;
-    r = sigemptyset(&sa.sa_mask);
+    int r = sigemptyset(&sa.sa_mask);
     if (r == -1) {
         twarn("sigemptyset()");
         exit(111);
@@ -71,8 +67,7 @@ set_sig_handlers()
 int
 main(int argc, char **argv)
 {
-    int r;
-    struct job list = {};
+    UNUSED_PARAMETER(argc);
 
     progname = argv[0];
     setlinebuf(stdout);
@@ -82,7 +77,7 @@ main(int argc, char **argv)
         printf("pid %d\n", getpid());
     }
 
-    r = make_server_socket(srv.addr, srv.port);
+    int r = make_server_socket(srv.addr, srv.port);
     if (r == -1) {
         twarnx("make_server_socket()");
         exit(111);
@@ -92,7 +87,8 @@ main(int argc, char **argv)
 
     prot_init();
 
-    if (srv.user) su(srv.user);
+    if (srv.user)
+        su(srv.user);
     set_sig_handlers();
 
     if (srv.wal.use) {
@@ -104,6 +100,7 @@ main(int argc, char **argv)
             exit(10);
         }
 
+        struct job list = {};
         list.prev = list.next = &list;
         walinit(&srv.wal, &list);
         r = prot_replay(&srv, &list);

--- a/prot.c
+++ b/prot.c
@@ -1654,8 +1654,9 @@ conn_timeout(Conn *c)
 }
 
 void
-enter_drain_mode(int sig)
+enter_drain_mode(int signum)
 {
+    UNUSED_PARAMETER(signum);
     drain_mode = 1;
 }
 
@@ -1918,13 +1919,11 @@ prottick(Server *s)
 void
 h_accept(const int fd, const short which, Server *s)
 {
-    Conn *c;
-    int cfd, flags, r;
-    socklen_t addrlen;
+    UNUSED_PARAMETER(which);
     struct sockaddr_in6 addr;
 
-    addrlen = sizeof addr;
-    cfd = accept(fd, (struct sockaddr *)&addr, &addrlen);
+    socklen_t addrlen = sizeof addr;
+    int cfd = accept(fd, (struct sockaddr *)&addr, &addrlen);
     if (cfd == -1) {
         if (errno != EAGAIN && errno != EWOULDBLOCK) twarn("accept()");
         update_conns();
@@ -1934,7 +1933,7 @@ h_accept(const int fd, const short which, Server *s)
         printf("accept %d\n", cfd);
     }
 
-    flags = fcntl(cfd, F_GETFL, 0);
+    int flags = fcntl(cfd, F_GETFL, 0);
     if (flags < 0) {
         twarn("getting flags");
         close(cfd);
@@ -1945,7 +1944,7 @@ h_accept(const int fd, const short which, Server *s)
         return;
     }
 
-    r = fcntl(cfd, F_SETFL, flags | O_NONBLOCK);
+    int r = fcntl(cfd, F_SETFL, flags | O_NONBLOCK);
     if (r < 0) {
         twarn("setting O_NONBLOCK");
         close(cfd);
@@ -1956,7 +1955,7 @@ h_accept(const int fd, const short which, Server *s)
         return;
     }
 
-    c = make_conn(cfd, STATE_WANTCOMMAND, default_tube, default_tube);
+    Conn *c = make_conn(cfd, STATE_WANTCOMMAND, default_tube, default_tube);
     if (!c) {
         twarnx("make_conn() failed");
         close(cfd);

--- a/sd-daemon.c
+++ b/sd-daemon.c
@@ -43,9 +43,12 @@
 
 #include "sd-daemon.h"
 
+#define UNUSED_PARAMETER(x) (void)(x)
+
 int sd_listen_fds(int unset_environment) {
 
 #if defined(DISABLE_SYSTEMD) || !defined(__linux__)
+        UNUSED_PARAMETER(unset_environment);
         return 0;
 #else
         int r, fd;
@@ -326,6 +329,8 @@ int sd_is_socket_unix(int fd, int type, int listening, const char *path, size_t 
 
 int sd_notify(int unset_environment, const char *state) {
 #if defined(DISABLE_SYSTEMD) || !defined(__linux__) || !defined(SOCK_CLOEXEC)
+        UNUSED_PARAMETER(unset_environment);
+        UNUSED_PARAMETER(state);
         return 0;
 #else
         int fd = -1, r;
@@ -394,6 +399,8 @@ finish:
 
 int sd_notifyf(int unset_environment, const char *format, ...) {
 #if defined(DISABLE_SYSTEMD) || !defined(__linux__)
+        UNUSED_PARAMETER(unset_environment);
+        UNUSED_PARAMETER(format);
         return 0;
 #else
         va_list ap;

--- a/serv.c
+++ b/serv.c
@@ -4,11 +4,9 @@
 #include "dat.h"
 
 struct Server srv = {
-    Portdef,
-    NULL,
-    NULL,
-    {
-        Filesizedef,
+    .port = Portdef,
+    .wal = {
+        .filesize = Filesizedef,
     },
 };
 

--- a/testserv.c
+++ b/testserv.c
@@ -27,7 +27,7 @@ static byte fallocpat[3];
 static int
 wrapfalloc(int fd, int size)
 {
-    static int c = 0;
+    static size_t c = 0;
 
     printf("\nwrapfalloc: fd=%d size=%d\n", fd, size);
     if (c >= sizeof(fallocpat) || !fallocpat[c++]) {


### PR DESCRIPTION
Parameters marked with the UNUSED_PARAMETERS macros cannot be
removed from functions because their prototypes cannot be changed.

Create the srv struct via designated initializers. Also remove NULL
assigment, because this way struct values are set to 0 anyway.

Also declare vars next to their first usage as usual.

Update #443 