### PR TITLE
use size_t for indexes in the heap structure

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -31,7 +31,7 @@ typedef struct Wal    Wal;
 typedef void(*ms_event_fn)(ms a, void *item, size_t i);
 typedef void(*Handle)(void*, int rw);
 typedef int(*Less)(void*, void*);
-typedef void(*Record)(void*, int);
+typedef void(*Record)(void*, size_t);
 typedef int(FAlloc)(int, int);
 
 #if _LP64
@@ -81,14 +81,14 @@ struct stats {
 
 
 struct Heap {
-    int     cap;
-    int     len;
+    size_t  cap;
+    size_t  len;
     void    **data;
     Less    less;
     Record  rec;
 };
 int   heapinsert(Heap *h, void *x);
-void* heapremove(Heap *h, int k);
+void* heapremove(Heap *h, size_t k);
 
 
 struct Socket {
@@ -210,7 +210,7 @@ void job_free(job j);
 job job_find(uint64 job_id);
 
 /* the void* parameters are really job pointers */
-void job_setheappos(void*, int);
+void job_setheappos(void*, size_t);
 int job_pri_less(void*, void*);
 int job_delay_less(void*, void*);
 

--- a/heap.c
+++ b/heap.c
@@ -5,7 +5,7 @@
 
 
 static void
-set(Heap *h, int k, void *x)
+set(Heap *h, size_t k, void *x)
 {
     h->data[k] = x;
     h->rec(x, k);
@@ -13,7 +13,7 @@ set(Heap *h, int k, void *x)
 
 
 static void
-swap(Heap *h, int a, int b)
+swap(Heap *h, size_t a, size_t b)
 {
     void *tmp;
 
@@ -24,17 +24,17 @@ swap(Heap *h, int a, int b)
 
 
 static int
-less(Heap *h, int a, int b)
+less(Heap *h, size_t a, size_t b)
 {
     return h->less(h->data[a], h->data[b]);
 }
 
 
 static void
-siftdown(Heap *h, int k)
+siftdown(Heap *h, size_t k)
 {
     for (;;) {
-        int p = (k-1) / 2; /* parent */
+        size_t p = (k-1) / 2; /* parent */
 
         if (k == 0 || less(h, p, k)) {
             return;
@@ -47,16 +47,14 @@ siftdown(Heap *h, int k)
 
 
 static void
-siftup(Heap *h, int k)
+siftup(Heap *h, size_t k)
 {
     for (;;) {
-        int l, r, s;
-
-        l = k*2 + 1; /* left child */
-        r = k*2 + 2; /* right child */
+        size_t l = k*2 + 1; /* left child */
+        size_t r = k*2 + 2; /* right child */
 
         /* find the smallest of the three */
-        s = k;
+        size_t s = k;
         if (l < h->len && less(h, l, s)) s = l;
         if (r < h->len && less(h, r, s)) s = r;
 
@@ -75,24 +73,22 @@ siftup(Heap *h, int k)
 int
 heapinsert(Heap *h, void *x)
 {
-    int k;
-
     if (h->len == h->cap) {
         void **ndata;
-        int ncap = (h->len+1) * 2; /* allocate twice what we need */
+        size_t ncap = (h->len+1) * 2; /* allocate twice what we need */
 
         ndata = malloc(sizeof(void*) * ncap);
         if (!ndata) {
             return 0;
         }
 
-        memcpy(ndata, h->data, sizeof(void*)*h->len);
+        memcpy(ndata, h->data, sizeof(void*) * h->len);
         free(h->data);
         h->data = ndata;
         h->cap = ncap;
     }
 
-    k = h->len;
+    size_t k = h->len;
     h->len++;
     set(h, k, x);
     siftdown(h, k);
@@ -101,19 +97,16 @@ heapinsert(Heap *h, void *x)
 
 
 void *
-heapremove(Heap *h, int k)
+heapremove(Heap *h, size_t k)
 {
-    void *x;
-
     if (k >= h->len) {
         return 0;
     }
 
-    x = h->data[k];
+    void *x = h->data[k];
     h->len--;
     set(h, k, h->data[h->len]);
     siftdown(h, k);
     siftup(h, k);
-    h->rec(x, -1);
     return x;
 }

--- a/job.c
+++ b/job.c
@@ -158,7 +158,7 @@ job_free(job j)
 }
 
 void
-job_setheappos(void *j, int pos)
+job_setheappos(void *j, size_t pos)
 {
     ((job)j)->heap_index = pos;
 }

--- a/prot.c
+++ b/prot.c
@@ -193,9 +193,9 @@ size_t job_data_size_limit = JOB_DATA_SIZE_LIMIT_DEFAULT;
 #define STATS_TUBE_FMT "---\n" \
     "name: %s\n" \
     "current-jobs-urgent: %u\n" \
-    "current-jobs-ready: %u\n" \
+    "current-jobs-ready: %zu\n" \
     "current-jobs-reserved: %u\n" \
-    "current-jobs-delayed: %u\n" \
+    "current-jobs-delayed: %zu\n" \
     "current-jobs-buried: %u\n" \
     "total-jobs: %" PRIu64 "\n" \
     "current-using: %u\n" \

--- a/testheap.c
+++ b/testheap.c
@@ -10,13 +10,12 @@
 void
 cttest_heap_insert_one()
 {
-    Heap h = {0};
-    job j;
+    Heap h = {
+        .less = job_pri_less,
+        .rec = job_setheappos,
+    };
 
-    h.less = job_pri_less;
-    h.rec = job_setheappos;
-
-    j = make_job(1, 0, 1, 0, 0);
+    job j = make_job(1, 0, 1, 0, 0);
     assertf(j, "allocate job");
 
     heapinsert(&h, j);
@@ -27,34 +26,31 @@ cttest_heap_insert_one()
 void
 cttest_heap_insert_and_remove_one()
 {
-    Heap h = {0};
-    int r;
-    job j, j1;
+    Heap h = {
+        .less = job_pri_less,
+        .rec = job_setheappos,
+    };
 
-    h.less = job_pri_less;
-    h.rec = job_setheappos;
-    j1 = make_job(1, 0, 1, 0, 0);
+    job j1 = make_job(1, 0, 1, 0, 0);
     assertf(j1, "allocate job");
 
-    r = heapinsert(&h, j1);
+    int r = heapinsert(&h, j1);
     assertf(r, "insert should succeed");
 
-    j = heapremove(&h, 0);
-    assertf(j == j1, "j1 should come back out");
+    job got = heapremove(&h, 0);
+    assertf(got == j1, "j1 should come back out");
     assertf(h.len == 0, "h should be empty.");
-    printf("j->heap_index is %zu\n", j->heap_index);
-    assertf(j->heap_index == -1, "j's heap index should be invalid");
 }
 
 void
 cttest_heap_priority()
 {
-    Heap h = {0};
-    int r;
+    Heap h = {
+        .less = job_pri_less,
+        .rec = job_setheappos,
+    };
     job j, j1, j2, j3;
 
-    h.less = job_pri_less;
-    h.rec = job_setheappos;
     j1 = make_job(1, 0, 1, 0, 0);
     j2 = make_job(2, 0, 1, 0, 0);
     j3 = make_job(3, 0, 1, 0, 0);
@@ -62,7 +58,7 @@ cttest_heap_priority()
     assertf(j2, "allocate job");
     assertf(j3, "allocate job");
 
-    r = heapinsert(&h, j2);
+    int r = heapinsert(&h, j2);
     assertf(r, "insert should succeed");
     assertf(j2->heap_index == 0, "should match");
 
@@ -93,12 +89,12 @@ cttest_heap_priority()
 void
 cttest_heap_fifo_property()
 {
-    Heap h = {0};
-    int r;
+    Heap h = {
+        .less = job_pri_less,
+        .rec = job_setheappos,
+    };
     job j, j3a, j3b, j3c;
 
-    h.less = job_pri_less;
-    h.rec = job_setheappos;
     j3a = make_job(3, 0, 1, 0, 0);
     j3b = make_job(3, 0, 1, 0, 0);
     j3c = make_job(3, 0, 1, 0, 0);
@@ -106,7 +102,7 @@ cttest_heap_fifo_property()
     assertf(j3b, "allocate job");
     assertf(j3c, "allocate job");
 
-    r = heapinsert(&h, j3a);
+    int r = heapinsert(&h, j3a);
     assertf(r, "insert should succeed");
     assertf(h.data[0] == j3a, "j3a should be in pos 0");
     assertf(j3a->heap_index == 0, "should match");
@@ -140,22 +136,22 @@ cttest_heap_fifo_property()
 void
 cttest_heap_many_jobs()
 {
-    Heap h = {0};
-    uint last_pri;
-    int r, i, n = 20;
+    Heap h = {
+        .less = job_pri_less,
+        .rec = job_setheappos,
+    };
+    const int n = 20;
     job j;
 
-    h.less = job_pri_less;
-    h.rec = job_setheappos;
-
+    int i;
     for (i = 0; i < n; i++) {
         j = make_job(1 + rand() % 8192, 0, 1, 0, 0);
         assertf(j, "allocation");
-        r = heapinsert(&h, j);
+        int r = heapinsert(&h, j);
         assertf(r, "heapinsert");
     }
 
-    last_pri = 0;
+    uint last_pri = 0;
     for (i = 0; i < n; i++) {
         j = heapremove(&h, 0);
         assertf(j->r.pri >= last_pri, "should come out in order");
@@ -166,19 +162,18 @@ cttest_heap_many_jobs()
 void
 cttest_heap_remove_k()
 {
-    Heap h = {0};
-    uint last_pri;
-    int r, i, c, n = 20;
-    job j;
+    Heap h = {
+        .less = job_pri_less,
+        .rec = job_setheappos,
+    };
+    const int n = 20;
 
-    h.less = job_pri_less;
-    h.rec = job_setheappos;
-
+    int c, i;
     for (c = 0; c < 50; c++) {
         for (i = 0; i < n; i++) {
-            j = make_job(1 + rand() % 8192, 0, 1, 0, 0);
+            job j = make_job(1 + rand() % 8192, 0, 1, 0, 0);
             assertf(j, "allocation");
-            r = heapinsert(&h, j);
+            int r = heapinsert(&h, j);
             assertf(r, "heapinsert");
         }
 
@@ -186,9 +181,9 @@ cttest_heap_remove_k()
         heapremove(&h, 25);
 
         /* now make sure the rest are still a valid heap */
-        last_pri = 0;
+        uint last_pri = 0;
         for (i = 1; i < n; i++) {
-            j = heapremove(&h, 0);
+            job j = heapremove(&h, 0);
             assertf(j->r.pri >= last_pri, "should come out in order");
             last_pri = j->r.pri;
         }
@@ -198,18 +193,18 @@ cttest_heap_remove_k()
 void
 ctbench_heap_insert(int n)
 {
-    job *j;
-    int i;
-    j = calloc(n, sizeof *j);
+    job *j = calloc(n, sizeof *j);
     assert(j);
+    int i;
     for (i = 0; i < n; i++) {
         j[i] = make_job(1, 0, 1, 0, 0);
         assert(j[i]);
         j[i]->r.pri = -j[i]->r.id;
     }
-    Heap h = {0};
-    h.less = job_pri_less;
-    h.rec = job_setheappos;
+    Heap h = {
+        .less = job_pri_less,
+        .rec = job_setheappos,
+    };
     ctresettimer();
     for (i = 0; i < n; i++) {
         heapinsert(&h, j[i]);
@@ -219,14 +214,14 @@ ctbench_heap_insert(int n)
 void
 ctbench_heap_remove(int n)
 {
-    Heap h = {0};
-    job j;
-    int i;
+    Heap h = {
+        .less = job_pri_less,
+        .rec = job_setheappos,
+    };
 
-    h.less = job_pri_less;
-    h.rec = job_setheappos;
+    int i;
     for (i = 0; i < n; i++) {
-        j = make_job(1, 0, 1, 0, 0);
+        job j = make_job(1, 0, 1, 0, 0);
         assertf(j, "allocate job");
         heapinsert(&h, j);
     }

--- a/testserv.c
+++ b/testserv.c
@@ -89,6 +89,7 @@ mustdiallocal(int port)
 static void
 exit_process(int signum)
 {
+    UNUSED_PARAMETER(signum);
     exit(0);
 }
 


### PR DESCRIPTION
Previously "int" was used, it may be too small on some architectures.
This change uses "size_t" instead, since index cannot be negative.

In the heapremove function it removes the assignment to the heap_index
field of deleted member.

As usual in affected functions, I have moved  declarations of variables close
to their usage.

Updates #443