### PR TITLE
compile beanstalkd in c99 mode by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX?=/usr/local
 BINDIR=$(DESTDIR)$(PREFIX)/bin
 
-override CFLAGS+=-Wall -Werror -Wformat=2 -g
+override CFLAGS+=-Wall -Werror -Wformat=2 -g -std=c99
 override LDFLAGS?=
 
 LDLIBS?=


### PR DESCRIPTION
Some old compilers requires the -std=c99 parameter, so we can use
features of c99 without errors:
`‘for’ loop initial declarations are only allowed in C99 mode`

Failed build: https://travis-ci.org/beanstalkd/beanstalkd/jobs/556849984