### PR TITLE
fix the job size overflowing the int type and set hard limit on it

### DIFF
--- a/testutil.c
+++ b/testutil.c
@@ -105,6 +105,18 @@ cttest_optz()
 }
 
 void
+cttest_optz_more_than_max()
+{
+    char *args[] = {
+        "-z1073741825",
+        NULL,
+    };
+
+    optparse(&srv, args);
+    assert(job_data_size_limit == 1073741824);
+}
+
+void
 cttest_opts()
 {
     char *args[] = {

--- a/util.c
+++ b/util.c
@@ -106,7 +106,7 @@ usage(int code)
             " -l ADDR  listen on address (default is 0.0.0.0)\n"
             " -p PORT  listen on port (default is " Portdef ")\n"
             " -u USER  become user and group\n"
-            " -z BYTES set the maximum job size in bytes (default is %d)\n"
+            " -z BYTES set the maximum job size in bytes (default is %d, max allowed is %d)\n"
             " -s BYTES set the size of each write-ahead log file (default is %d)\n"
             "            (will be rounded up to a multiple of 512 bytes)\n"
             " -c       compact the binlog (default)\n"
@@ -114,7 +114,10 @@ usage(int code)
             " -v       show version information\n"
             " -V       increase verbosity\n"
             " -h       show this help\n",
-            progname, JOB_DATA_SIZE_LIMIT_DEFAULT, Filesizedef);
+            progname,
+            JOB_DATA_SIZE_LIMIT_DEFAULT,
+            JOB_DATA_SIZE_LIMIT_MAX,
+            Filesizedef);
     exit(code);
 }
 
@@ -163,6 +166,10 @@ optparse(Server *s, char **argv)
                     break;
                 case 'z':
                     job_data_size_limit = parse_size_t(EARGF(flagusage("-z")));
+                    if (job_data_size_limit > JOB_DATA_SIZE_LIMIT_MAX) {
+                        warnx("maximum job size was set to %d", JOB_DATA_SIZE_LIMIT_MAX);
+                        job_data_size_limit = JOB_DATA_SIZE_LIMIT_MAX;
+                    }
                     break;
                 case 's':
                     s->wal.filesize = parse_size_t(EARGF(flagusage("-s")));


### PR DESCRIPTION
I have set the maximum allowed limit for the job size to 1024^3 bytes (1GB).
When user tries to specify (-z) the limit for the job size larger than that,
he will get a warning that limit was capped to 1GB.

The program stores body_size in int32 (see struct Jobrec) and verifies that 
parameter in the put command can be parsed and fit into int32. 
I have propagated changes to the type of all involved functions.

Fixes #401