### PR TITLE
Use optimization flags on benchmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ jobs:
       os: linux
       compiler: gcc
       env:
-          - CFLAGS="-O3"
+          - CFLAGS="-march=native -mtune=native -O3"
       before_script:
           - export COVERAGE=OFF
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,9 +72,10 @@ jobs:
     - stage: Benchmark
       os: linux
       compiler: gcc
+      env:
+          - CFLAGS="-O3"
       before_script:
           - export COVERAGE=OFF
-          - export CFLAGS="-O3"
       script:
           - make $MAKEJOBS
           - make $MAKEJOBS bench

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,16 @@ jobs:
     - stage: Benchmark
       os: osx
       compiler: clang
+      env:
+          - CFLAGS="-march=native -mtune=native -O3"
+      before_script:
+          - export COVERAGE=OFF
+      script:
+          - make $MAKEJOBS
+          - make $MAKEJOBS bench
+    - stage: Benchmark
+      os: osx
+      compiler: clang
       before_script:
           - export COVERAGE=OFF
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,15 @@ jobs:
           - make $MAKEJOBS
           - make $MAKEJOBS bench
     - stage: Benchmark
+      os: linux
+      compiler: gcc
+      before_script:
+          - export COVERAGE=OFF
+          - export CFLAGS="-O3"
+      script:
+          - make $MAKEJOBS
+          - make $MAKEJOBS bench
+    - stage: Benchmark
       os: osx
       compiler: clang
       before_script:


### PR DESCRIPTION
Closes: https://github.com/beanstalkd/beanstalkd/issues/423

----

Just for history:

**gcc**
- gcc (Ubuntu 4.8.4-2ubuntu1~14.04.3) 4.8.4

```
CFLAGS=""
--
ctbench_heap_insert	 2000000	       750 ns/op
ctbench_heap_remove	 1000000	      1317 ns/op
ctbench_make_job	10000000	       256 ns/op
ctbench_put_delete_1k	     100	  39684462 ns/op	   0.03 MB/s
ctbench_put_delete_64k	     100	  38777774 ns/op	   2.12 MB/s
ctbench_put_delete_8	     100	  39606825 ns/op	   0.00 MB/s
ctbench_put_delete_8k	     100	  39572750 ns/op	   0.26 MB/s
```

```
CFLAGS="-march=native -mtune=native -O3"
--
ctbench_heap_insert	10000000	       209 ns/op
ctbench_heap_remove	 3000000	       624 ns/op
ctbench_make_job	10000000	       203 ns/op
ctbench_put_delete_1k	     100	  39587950 ns/op	   0.03 MB/s
ctbench_put_delete_64k	     100	  39173667 ns/op	   2.12 MB/s
ctbench_put_delete_8	     100	  39576659 ns/op	   0.00 MB/s
ctbench_put_delete_8k	     100	  39576587 ns/op	   0.26 MB/s
```

**Clang**
- Apple LLVM version 9.1.0 (clang-902.0.39.2)
- Target: x86_64-apple-darwin17.4.0
- Thread model: posix
```
CFLAGS=""
--
ctbench_heap_insert	 2000000	       640 ns/op
ctbench_heap_remove	 1000000	      1146 ns/op
ctbench_make_job	 5000000	       392 ns/op
ctbench_put_delete_1k	    3000	    569214 ns/op	   2.87 MB/s
ctbench_put_delete_64k	    2000	    851010 ns/op	 122.47 MB/s
ctbench_put_delete_8	    3000	    502608 ns/op	   0.02 MB/s
ctbench_put_delete_8k	    2000	    593672 ns/op	  16.08 MB/s
```

```
CFLAGS="-march=native -mtune=native -O3"
--
ctbench_heap_insert	10000000	       226 ns/op
ctbench_heap_remove	 5000000	       459 ns/op
ctbench_make_job	 5000000	       307 ns/op
ctbench_put_delete_1k	    3000	    467135 ns/op	   2.95 MB/s
ctbench_put_delete_64k	    2000	    738619 ns/op	 125.10 MB/s
ctbench_put_delete_8	    3000	    456176 ns/op	   0.02 MB/s
ctbench_put_delete_8k	    3000	    506332 ns/op	  23.36 MB/s
```