### PR TITLE
include dependent headers in the dat.h file

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -1,11 +1,11 @@
+#include "dat.h"
+#include <errno.h>
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
-#include <limits.h>
 #include <unistd.h>
-#include "dat.h"
 
 #define SAFETY_MARGIN (1000000000) /* 1 second */
 

--- a/darwin.c
+++ b/darwin.c
@@ -1,3 +1,4 @@
+#include "dat.h"
 #include <stdint.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -6,7 +7,6 @@
 #include <errno.h>
 #include <sys/event.h>
 #include <sys/time.h>
-#include "dat.h"
 
 enum
 {

--- a/dat.h
+++ b/dat.h
@@ -1,6 +1,5 @@
-// Requirements:
-// #include <stdint.h>
-// #include <stdlib.h>
+#include <stdint.h>
+#include <stdlib.h>
 
 typedef unsigned char uchar;
 typedef uchar         byte;
@@ -10,18 +9,10 @@ typedef uint32_t      uint32;
 typedef int64_t       int64;
 typedef uint64_t      uint64;
 
-#define int8_t   do_not_use_int8_t
-#define uint8_t  do_not_use_uint8_t
-#define int32_t  do_not_use_int32_t
-#define uint32_t do_not_use_uint32_t
-#define int64_t  do_not_use_int64_t
-#define uint64_t do_not_use_uint64_t
-
 /* TODO: typedefs of ms, job and tube should not hide the pointer.
    Make them similar to other typedefs (Conn, Heap).
    Maybem move each typedef next to the corresponding struct definition.
    See issue #458. */
-
 typedef struct ms     *ms;
 typedef struct job    *job;
 typedef struct tube   *tube;

--- a/file.c
+++ b/file.c
@@ -1,3 +1,4 @@
+#include "dat.h"
 #include <stdint.h>
 #include <inttypes.h>
 #include <stddef.h>
@@ -10,7 +11,6 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <string.h>
-#include "dat.h"
 
 static int  readrec(File*, job, int*);
 static int  readrec5(File*, job, int*);

--- a/heap.c
+++ b/heap.c
@@ -1,7 +1,7 @@
+#include "dat.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include "dat.h"
 
 
 static void

--- a/job.c
+++ b/job.c
@@ -1,7 +1,7 @@
+#include "dat.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include "dat.h"
 
 static uint64 next_id = 1;
 

--- a/linux.c
+++ b/linux.c
@@ -1,4 +1,6 @@
 #define _XOPEN_SOURCE 600
+
+#include "dat.h"
 #include <unistd.h>
 #include <sys/types.h>
 #include <stdint.h>
@@ -6,7 +8,6 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/epoll.h>
-#include "dat.h"
 
 #ifndef EPOLLRDHUP
 #define EPOLLRDHUP 0x2000

--- a/main.c
+++ b/main.c
@@ -1,3 +1,4 @@
+#include "dat.h"
 #include <stdint.h>
 #include <signal.h>
 #include <stdio.h>
@@ -7,7 +8,6 @@
 #include <unistd.h>
 #include <pwd.h>
 #include <fcntl.h>
-#include "dat.h"
 
 static void
 su(const char *user) 

--- a/ms.c
+++ b/ms.c
@@ -1,7 +1,7 @@
+#include "dat.h"
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
-#include "dat.h"
 
 void
 ms_init(ms a, ms_event_fn oninsert, ms_event_fn onremove)

--- a/net.c
+++ b/net.c
@@ -1,3 +1,5 @@
+#include "dat.h"
+#include "sd-daemon.h"
 #include <netdb.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -7,8 +9,6 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
-#include "dat.h"
-#include "sd-daemon.h"
 
 int
 make_server_socket(char *host, char *port)

--- a/prot.c
+++ b/prot.c
@@ -1,3 +1,4 @@
+#include "dat.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -13,7 +14,6 @@
 #include <netinet/in.h>
 #include <inttypes.h>
 #include <stdarg.h>
-#include "dat.h"
 
 /* job body cannot be greater than this many bytes long */
 size_t job_data_size_limit = JOB_DATA_SIZE_LIMIT_DEFAULT;

--- a/serv.c
+++ b/serv.c
@@ -1,7 +1,7 @@
+#include "dat.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/socket.h>
-#include "dat.h"
 
 struct Server srv = {
     .port = Portdef,

--- a/testheap.c
+++ b/testheap.c
@@ -1,10 +1,10 @@
+#include "dat.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/time.h>
 #include "ct/ct.h"
-#include "dat.h"
 
 
 void

--- a/testjobs.c
+++ b/testjobs.c
@@ -1,10 +1,10 @@
+#include "ct/ct.h"
+#include "dat.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/time.h>
-#include "ct/ct.h"
-#include "dat.h"
 
 static tube default_tube;
 

--- a/testserv.c
+++ b/testserv.c
@@ -1,3 +1,5 @@
+#include "ct/ct.h"
+#include "dat.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -15,8 +17,6 @@
 #include <fcntl.h>
 #include <sys/wait.h>
 #include <errno.h>
-#include "ct/ct.h"
-#include "dat.h"
 
 static int srvpid, port, fd, size;
 static int64 timeout = 5000000000LL; // 5s

--- a/testutil.c
+++ b/testutil.c
@@ -1,11 +1,11 @@
+#include "ct/ct.h"
+#include "dat.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/time.h>
 #include <unistd.h>
-#include "ct/ct.h"
-#include "dat.h"
 
 void
 cttest_allocf()

--- a/time.c
+++ b/time.c
@@ -1,7 +1,7 @@
+#include "dat.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/time.h>
-#include "dat.h"
 
 int64
 nanoseconds(void)

--- a/tube.c
+++ b/tube.c
@@ -1,7 +1,7 @@
+#include "dat.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include "dat.h"
 
 struct ms tubes;
 

--- a/util.c
+++ b/util.c
@@ -1,3 +1,4 @@
+#include "dat.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -5,7 +6,6 @@
 #include <string.h>
 #include <stdarg.h>
 #include "sd-daemon.h"
-#include "dat.h"
 
 const char *progname;
 

--- a/walg.c
+++ b/walg.c
@@ -1,3 +1,4 @@
+#include "dat.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -9,7 +10,6 @@
 #include <sys/uio.h>
 #include <sys/stat.h>
 #include <limits.h>
-#include "dat.h"
 
 static int reserve(Wal *w, int n);
 


### PR DESCRIPTION
Before this fix my editor was hinting the `*_t` types as undefined. This was confusing.

I have rearranged dat.h and sd-daemon.h before other headers to verify this.
I have removed redefinitions of *_t types because it was producing redefinitions errors.