### PR TITLE
test peek* and kick commands

### DIFF
--- a/prot.c
+++ b/prot.c
@@ -1309,7 +1309,7 @@ dispatch_cmd(Conn *c)
 
         /* So, peek is annoying, because some other connection might free the
          * job while we are still trying to write it out. So we copy it and
-         * then free the copy when it's done sending. */
+         * free the copy when it's done sending, in the "reset_conn" function. */
         j = job_copy(peek_job(id));
 
         if (!j) return reply(c, MSG_NOTFOUND, MSG_NOTFOUND_LEN, STATE_SENDWORD);


### PR DESCRIPTION
Drain mode was quickly tested as well.

The cttest_peek_bad_format test function is commented
until the issue #464 is fixed.

Updates #424
