### PR TITLE
fix flaky deadline-soon test

### DIFF
--- a/testserv.c
+++ b/testserv.c
@@ -701,8 +701,8 @@ cttest_reserve_ttr_deadline_soon()
     ckrespsub(prod, "OK ");
     ckrespsub(prod, "\nstate: reserved\n");
 
-    // After 0.5s the job should time out and be ready again.
-    usleep(500000);
+    // After 0.6s the job should time out and be ready again.
+    usleep(600000);
     mustsend(prod, "stats-job 1\r\n");
     ckrespsub(prod, "OK ");
     ckrespsub(prod, "\nstate: ready\n");


### PR DESCRIPTION
Test should spend more time than ttr to get job released back into the queue.