### PR TITLE
fix how connections are handled in the srv->conns heap

### DIFF
--- a/prot.c
+++ b/prot.c
@@ -1864,6 +1864,7 @@ prothandle(Conn *c, int ev)
     h_conn(c->sock.fd, ev, c);
 }
 
+// prottick returns nanoseconds till the next work.
 int64
 prottick(Server *s)
 {
@@ -1899,6 +1900,8 @@ prottick(Server *s)
         }
     }
 
+    // Process connections with pending timeouts. Release jobs with expired ttr.
+    // Capture the period from the soonest connection.
     while (s->conns.len) {
         Conn *c = s->conns.data[0];
         d = c->tickat - now;
@@ -1908,6 +1911,7 @@ prottick(Server *s)
         }
 
         heapremove(&s->conns, 0);
+        c->in_conns = 0;
         conn_timeout(c);
     }
 


### PR DESCRIPTION
Previously in #453 I have changed the type of position in the heap to size_t.
I have removed the call x->rec(x, -1) for the item being removed from the heap.

That patch has broken the meaning of conn->tickpos var, that used to
contain -1 when conn was not in the srv->conns heap. -1 was assigned
only when conn was created. Later when it was just removed from conns,
it was not ever assigned -1 again.

This change fixes how connections are handled in the srv->conns heap.
New var Conn->in_conns is used to track if conn exists in the heap.
Conn->tickpos is size_it and the connrec function has a prototype
matching the heap's Record prototype.

Fixes #472