### PR TITLE
fix prototypes of the Less and Record typedefs

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -209,16 +209,18 @@ conn_ready(Conn *c)
 
 
 int
-connless(Conn *a, Conn *b)
+conn_less(void *ca, void *cb)
 {
+    Conn *a = (Conn *)ca;
+    Conn *b = (Conn *)cb;
     return a->tickat < b->tickat;
 }
 
 
 void
-connrec(Conn *c, size_t i)
+conn_setpos(void *c, size_t i)
 {
-    c->tickpos = i;
+    ((Conn *)c)->tickpos = i;
 }
 
 

--- a/heap.c
+++ b/heap.c
@@ -8,7 +8,7 @@ static void
 set(Heap *h, size_t k, void *x)
 {
     h->data[k] = x;
-    h->rec(x, k);
+    h->setpos(x, k);
 }
 
 

--- a/job.c
+++ b/job.c
@@ -158,24 +158,26 @@ job_free(job j)
 }
 
 void
-job_setheappos(void *j, size_t pos)
+job_setpos(void *j, size_t pos)
 {
     ((job)j)->heap_index = pos;
 }
 
 int
-job_pri_less(void *ax, void *bx)
+job_pri_less(void *ja, void *jb)
 {
-    job a = ax, b = bx;
+    job a = (job)ja;
+    job b = (job)jb;
     if (a->r.pri < b->r.pri) return 1;
     if (a->r.pri > b->r.pri) return 0;
     return a->r.id < b->r.id;
 }
 
 int
-job_delay_less(void *ax, void *bx)
+job_delay_less(void *ja, void *jb)
 {
-    job a = ax, b = bx;
+    job a = ja;
+    job b = jb;
     if (a->r.deadline_at < b->r.deadline_at) return 1;
     if (a->r.deadline_at > b->r.deadline_at) return 0;
     return a->r.id < b->r.id;

--- a/serv.c
+++ b/serv.c
@@ -25,8 +25,8 @@ srvserve(Server *s)
 
     s->sock.x = s;
     s->sock.f = (Handle)srvaccept;
-    s->conns.less = (Less)connless;
-    s->conns.rec = (Record)connrec;
+    s->conns.less = conn_less;
+    s->conns.setpos = conn_setpos;
 
     r = listen(s->sock.fd, 1024);
     if (r == -1) {

--- a/testheap.c
+++ b/testheap.c
@@ -12,7 +12,7 @@ cttest_heap_insert_one()
 {
     Heap h = {
         .less = job_pri_less,
-        .rec = job_setheappos,
+        .setpos = job_setpos,
     };
 
     job j = make_job(1, 0, 1, 0, 0);
@@ -28,7 +28,7 @@ cttest_heap_insert_and_remove_one()
 {
     Heap h = {
         .less = job_pri_less,
-        .rec = job_setheappos,
+        .setpos = job_setpos,
     };
 
     job j1 = make_job(1, 0, 1, 0, 0);
@@ -47,7 +47,7 @@ cttest_heap_priority()
 {
     Heap h = {
         .less = job_pri_less,
-        .rec = job_setheappos,
+        .setpos = job_setpos,
     };
     job j, j1, j2, j3;
 
@@ -91,7 +91,7 @@ cttest_heap_fifo_property()
 {
     Heap h = {
         .less = job_pri_less,
-        .rec = job_setheappos,
+        .setpos = job_setpos,
     };
     job j, j3a, j3b, j3c;
 
@@ -138,7 +138,7 @@ cttest_heap_many_jobs()
 {
     Heap h = {
         .less = job_pri_less,
-        .rec = job_setheappos,
+        .setpos = job_setpos,
     };
     const int n = 20;
     job j;
@@ -164,7 +164,7 @@ cttest_heap_remove_k()
 {
     Heap h = {
         .less = job_pri_less,
-        .rec = job_setheappos,
+        .setpos = job_setpos,
     };
     const int n = 20;
 
@@ -203,7 +203,7 @@ ctbench_heap_insert(int n)
     }
     Heap h = {
         .less = job_pri_less,
-        .rec = job_setheappos,
+        .setpos = job_setpos,
     };
     ctresettimer();
     for (i = 0; i < n; i++) {
@@ -216,7 +216,7 @@ ctbench_heap_remove(int n)
 {
     Heap h = {
         .less = job_pri_less,
-        .rec = job_setheappos,
+        .setpos = job_setpos,
     };
 
     int i;

--- a/tube.c
+++ b/tube.c
@@ -19,8 +19,8 @@ make_tube(const char *name)
 
     t->ready.less = job_pri_less;
     t->delay.less = job_delay_less;
-    t->ready.rec = job_setheappos;
-    t->delay.rec = job_setheappos;
+    t->ready.setpos = job_setpos;
+    t->delay.setpos = job_setpos;
 
     struct job j = {.tube = NULL};
     t->buried = j;


### PR DESCRIPTION
This change improves readability of the code.
It brings consistency into functions of the binary heap.
Typedef Less was renamed to less_fn, Record to setpos_fn.
connless and connrec were changed to match to the corresponding typdefs.

The rec member of heap was renamed to "setpos".

The job was updated in the same way.

Fixes #472