### PR TITLE
fix benchmarks in testsrv.c

### DIFF
--- a/testjobs.c
+++ b/testjobs.c
@@ -132,6 +132,7 @@ ctbench_make_job(int n)
 {
     int i;
     TUBE_ASSIGN(default_tube, make_tube("default"));
+    ctresettimer();
     for (i = 0; i < n; i++) {
         make_job(0, 0, 1, 0, default_tube);
     }


### PR DESCRIPTION
The slowness in benchmarks on Linux was due to long wait time
in the select syscall. Setting socket's TCP_NODELAY helped.

Also see
https://stackoverflow.com/questions/39270419/select-on-socket-slow-in-linux

I added proper resettimers inside of benchmarks to skip the overhead.
This helped to improve the time spent in all of testsrv tests too.

Bechmarking is not ideal yet. It might be capped by the client's limitations.

Fixes #430