### PR TITLE
fix the id parsing in all commands and add tests

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -71,9 +71,6 @@ typedef int(FAlloc)(int, int);
 // The width is restricted by Jobrec.body_size that is int32.
 #define JOB_DATA_SIZE_LIMIT_MAX 1073741824
 
-// Maximum value (uint32) allowed in pri, delay and ttr parameters
-#define MAX_UINT32 4294967295
-
 // Use this macro to designate unused parameters in functions.
 #define UNUSED_PARAMETER(x) (void)(x)
 


### PR DESCRIPTION
This change fixes how IDs are parsed in all commands.
They are parsed into uint64 with full spectrum of checks.
I added the read_uint64 function identical to read_uint32 (former read_num).
Also read_uint* functions report values not falling into the range as invalid.

I have renamed definitions *_JOBKICK to *_KICKJOB because it was inverted from
actual command.

Updates #424
Fixes #464
