### PR TITLE
fix leaks in heap, ms, util tests

### DIFF
--- a/testheap.c
+++ b/testheap.c
@@ -21,6 +21,10 @@ cttest_heap_insert_one()
     heapinsert(&h, j);
     assertf(h.len == 1, "h should contain one item.");
     assertf(j->heap_index == 0, "should match");
+
+    assert(heapremove(&h, 0));
+    job_free(j);
+    free(h.data);
 }
 
 void
@@ -40,6 +44,9 @@ cttest_heap_insert_and_remove_one()
     job got = heapremove(&h, 0);
     assertf(got == j1, "j1 should come back out");
     assertf(h.len == 0, "h should be empty.");
+
+    free(h.data);
+    job_free(j1);
 }
 
 void
@@ -84,6 +91,11 @@ cttest_heap_priority()
 
     j = heapremove(&h, 0);
     assertf(j == j3, "j3 should come out third.");
+
+    free(h.data);
+    job_free(j1);
+    job_free(j2);
+    job_free(j3);
 }
 
 void
@@ -131,6 +143,11 @@ cttest_heap_fifo_property()
 
     j = heapremove(&h, 0);
     assertf(j == j3c, "j3c should come out third.");
+
+    free(h.data);
+    job_free(j3a);
+    job_free(j3b);
+    job_free(j3c);
 }
 
 void
@@ -156,7 +173,10 @@ cttest_heap_many_jobs()
         j = heapremove(&h, 0);
         assertf(j->r.pri >= last_pri, "should come out in order");
         last_pri = j->r.pri;
+        assert(j);
+        job_free(j);
     }
+    free(h.data);
 }
 
 void
@@ -166,7 +186,8 @@ cttest_heap_remove_k()
         .less = job_pri_less,
         .setpos = job_setpos,
     };
-    const int n = 20;
+    const int n = 50;
+    const int mid = 25;
 
     int c, i;
     for (c = 0; c < 50; c++) {
@@ -178,7 +199,9 @@ cttest_heap_remove_k()
         }
 
         /* remove one from the middle */
-        heapremove(&h, 25);
+        job j0 = heapremove(&h, mid);
+        assertf(j0, "j0 should not be NULL");
+        job_free(j0);
 
         /* now make sure the rest are still a valid heap */
         uint last_pri = 0;
@@ -186,8 +209,11 @@ cttest_heap_remove_k()
             job j = heapremove(&h, 0);
             assertf(j->r.pri >= last_pri, "should come out in order");
             last_pri = j->r.pri;
+            assertf(j, "j should not be NULL");
+            job_free(j);
         }
     }
+    free(h.data);
 }
 
 void

--- a/testms.c
+++ b/testms.c
@@ -17,7 +17,7 @@ cttest_ms_append()
 
     int ok = ms_append(a, &i);
     assertf(a->len == 1, "a should contain one item");
-    assertf(ok, "should be added"); 
+    assertf(ok, "should be added");
 
     ok = ms_append(a, &i);
     assertf(a->len == 2, "a should contain two items");
@@ -25,6 +25,7 @@ cttest_ms_append()
 
     ms_clear(a);
     assertf(a->len == 0, "a should be empty");
+    free(a->items);
     free(a);
 }
 
@@ -49,6 +50,7 @@ cttest_ms_remove()
     assertf(!ok, "i was already removed");
 
     assertf(a->len == 0, "a should be empty");
+    free(a->items);
     free(a);
 }
 
@@ -69,6 +71,7 @@ cttest_ms_contains()
     assertf(!ok, "j should not be in a");
 
     ms_clear(a);
+    free(a->items);
     free(a);
 }
 
@@ -81,6 +84,7 @@ cttest_ms_clear_empty()
 
     ms_clear(a);
     assertf(a->len == 0, "a should be empty");
+    free(a->items);
     free(a);
 }
 
@@ -106,6 +110,7 @@ cttest_ms_take()
     n = (int *)ms_take(a);
     assertf(n == NULL, "n should be NULL; ms is empty");
 
+    free(a->items);
     free(a);
 }
 
@@ -128,6 +133,7 @@ cttest_ms_take_sequence()
         assert(*got == e[i]);
     }
 
+    free(a->items);
     free(a);
 }
 

--- a/testutil.c
+++ b/testutil.c
@@ -14,6 +14,7 @@ cttest_allocf()
 
     got = fmtalloc("hello, %s %d", "world", 5);
     assertf(strcmp("hello, world 5", got) == 0, "got \"%s\"", got);
+    free(got);
 }
 
 void


### PR DESCRIPTION
Additionally, this patch fixes a bug in the cttest_heap_remove_k test. Leak in the server tests are not fixed and require an additional scrutiny. 

Updates #382