### PR TITLE
convert body to *char and adjust the job's allocation

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -213,7 +213,7 @@ struct Job {
     int walresv;
     int walused;
 
-    char body[];                // written separately to the wal
+    char *body;                 // written separately to the wal
 };
 
 struct Tube {
@@ -221,13 +221,13 @@ struct Tube {
     char name[MAX_TUBE_NAME_LEN];
     Heap ready;
     Heap delay;
-    Ms waiting; /* set of conns */
+    Ms waiting;                 // set of conns
     struct stats stat;
     uint using_ct;
     uint watching_ct;
     int64 pause;
     int64 deadline_at;
-    Job buried;
+    Job buried;                 // linked list header
 };
 
 

--- a/job.c
+++ b/job.c
@@ -95,12 +95,16 @@ allocate_job(int body_size)
     Job *j;
 
     j = malloc(sizeof(Job) + body_size);
-    if (!j) return twarnx("OOM"), (Job *) 0;
+    if (!j) {
+        twarnx("OOM");
+        return (Job *) 0;
+    }
 
     memset(j, 0, sizeof(Job));
     j->r.created_at = nanoseconds();
     j->r.body_size = body_size;
-    j->next = j->prev = j; /* not in a linked list */
+    j->body = (char *)j + sizeof(Job);
+    j->next = j->prev = j;      // not in a linked list
     return j;
 }
 


### PR DESCRIPTION
This fix is trivial and the only place needed adjustment was
initialization of the pointer in allocate_job.

Job is still allocated and freed as one block. Performance has
improved slightly, not sure if this just a statistical variance.
We lack proper benchmarking so I cannot say for sure.

Before:

```
ctbench_heap_insert	 3000000	       545 ns/op
ctbench_heap_remove	 1000000	      1003 ns/op
ctbench_make_job	 5000000	       272 ns/op
ctbench_put_delete_1k	    3000	    351086 ns/op	   3.06 MB/s
ctbench_put_delete_64k	    2000	    617025 ns/op	 128.07 MB/s
ctbench_put_delete_8	    5000	    342281 ns/op	   0.04 MB/s
ctbench_put_delete_8k	    3000	    413185 ns/op          24.00 MB/s
```
After:
```
ctbench_heap_insert	 3000000	       546 ns/op
ctbench_heap_remove	 2000000	      1041 ns/op
ctbench_make_job	 5000000	       254 ns/op
ctbench_put_delete_1k	    5000	    320182 ns/op	   4.83 MB/s
ctbench_put_delete_64k	    2000	    609554 ns/op	 128.26 MB/s
ctbench_put_delete_8	    5000	    312411 ns/op	   0.04 MB/s
ctbench_put_delete_8k	    5000	    371577 ns/op	  37.72 MB/s
```
Fixes #487.