### PR TITLE
[Feature] Allow reprioritizing queued jobs

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -111,6 +111,8 @@ struct Heap {
 int   heapinsert(Heap *h, void *x);
 void* heapremove(Heap *h, size_t k);
 
+void siftdown(Heap *h, size_t k);
+void siftup(Heap *h, size_t k);
 
 struct Socket {
     int    fd;

--- a/heap.c
+++ b/heap.c
@@ -30,7 +30,7 @@ less(Heap *h, size_t a, size_t b)
 }
 
 
-static void
+void
 siftdown(Heap *h, size_t k)
 {
     for (;;) {
@@ -46,7 +46,7 @@ siftdown(Heap *h, size_t k)
 }
 
 
-static void
+void
 siftup(Heap *h, size_t k)
 {
     for (;;) {

--- a/prot.c
+++ b/prot.c
@@ -98,7 +98,6 @@ size_t job_data_size_limit = JOB_DATA_SIZE_LIMIT_DEFAULT;
 #define MSG_EXPECTED_CRLF "EXPECTED_CRLF\r\n"
 #define MSG_JOB_TOO_BIG "JOB_TOO_BIG\r\n"
 #define MSG_ALREADY_RESERVED "ALREADY_RESERVED\r\n"
-#define MSG_NOOP "NOOP\r\n"
 
 #define STATE_WANTCOMMAND 0
 #define STATE_WANTDATA 1
@@ -707,8 +706,9 @@ reprioritize_job(Conn *c, Job *j, uint32 pri)
 {
     uint32 cur_pri = j->r.pri;
 
+    // noop
     if (cur_pri == pri) {
-        return 0;
+        return 1;
     }
 
     j->r.pri = pri;
@@ -1479,9 +1479,7 @@ dispatch_cmd(Conn *c)
             return reply_msg(c, MSG_ALREADY_RESERVED);
         }
 
-        if (!reprioritize_job(c, j, pri)) {
-            return reply_msg(c, MSG_NOOP);
-        }
+        reprioritize_job(c, j, pri);
 
         reply_msg(c, MSG_REPRIORITIZED);
         break;

--- a/testserv.c
+++ b/testserv.c
@@ -657,7 +657,7 @@ cttest_reprioritize_noop()
     ckresp(fd, "INSERTED 1\r\n");
 
     mustsend(fd, "reprioritize 1 1\r\n");
-    ckresp(fd, "NOOP\r\n");
+    ckresp(fd, "REPRIORITIZED\r\n");
 }
 
 void

--- a/testserv.c
+++ b/testserv.c
@@ -588,6 +588,96 @@ cttest_pause()
 }
 
 void
+cttest_reprioritize_ok()
+{
+    port = SERVER();
+    fd = mustdiallocal(port);
+
+    mustsend(fd, "put 1 0 1 1\r\n");
+    mustsend(fd, "a\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
+
+    mustsend(fd, "put 2 0 1 1\r\n");
+    mustsend(fd, "b\r\n");
+    ckresp(fd, "INSERTED 2\r\n");
+
+    mustsend(fd, "put 3 0 1 1\r\n");
+    mustsend(fd, "c\r\n");
+    ckresp(fd, "INSERTED 3\r\n");
+
+    mustsend(fd, "put 4 0 1 1\r\n");
+    mustsend(fd, "d\r\n");
+    ckresp(fd, "INSERTED 4\r\n");
+
+    mustsend(fd, "put 5 0 1 1\r\n");
+    mustsend(fd, "e\r\n");
+    ckresp(fd, "INSERTED 5\r\n");
+
+    mustsend(fd, "reprioritize 1 6\r\n");
+    ckresp(fd, "REPRIORITIZED\r\n");
+
+    mustsend(fd, "reserve\r\n");
+    ckresp(fd, "RESERVED 2 1\r\n");
+    ckresp(fd, "b\r\n");
+
+    mustsend(fd, "reprioritize 1 1\r\n");
+    ckresp(fd, "REPRIORITIZED\r\n");
+
+    mustsend(fd, "reserve\r\n");
+    ckresp(fd, "RESERVED 1 1\r\n");
+    ckresp(fd, "a\r\n");
+}
+
+void
+cttest_reprioritize_reserved_job()
+{
+    port = SERVER();
+    fd = mustdiallocal(port);
+
+    mustsend(fd, "put 0 0 1 1\r\n");
+    mustsend(fd, "a\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
+
+    mustsend(fd, "reserve\r\n");
+    ckresp(fd, "RESERVED 1 1\r\n");
+    ckresp(fd, "a\r\n");
+
+    mustsend(fd, "reprioritize 1 999\r\n");
+    ckresp(fd, "ALREADY_RESERVED\r\n");
+}
+
+void
+cttest_reprioritize_noop()
+{
+    port = SERVER();
+    fd = mustdiallocal(port);
+
+    mustsend(fd, "put 1 0 1 1\r\n");
+    mustsend(fd, "a\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
+
+    mustsend(fd, "reprioritize 1 1\r\n");
+    ckresp(fd, "NOOP\r\n");
+}
+
+void
+cttest_reprioritize_not_found()
+{
+    port = SERVER();
+    fd = mustdiallocal(port);
+
+    mustsend(fd, "put 0 0 1 1\r\n");
+    mustsend(fd, "a\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
+
+    mustsend(fd, "reprioritize 2 1\r\n");
+    ckresp(fd, "NOT_FOUND\r\n");
+
+    mustsend(fd, "reprioritize 18446744073709551615 1\r\n");  // UINT64_MAX
+    ckresp(fd, "NOT_FOUND\r\n");
+}
+
+void
 cttest_underscore()
 {
     port = SERVER();


### PR DESCRIPTION
Addresses: https://github.com/beanstalkd/beanstalkd/issues/20 which would be a helpful feature to have. This PR will update priority for ready, delayed, and buried jobs - and only sift the jobs tube heap if the job is in a ready state. 

Format: 
```
reprioritize <id> <pri>\r\n
```

Returns:

`REPRIORITIZED\r\n` on success/noop
`NOT_FOUND\r\n` when job id not found
`ALREADY_RESERVED\r\n` when job has already been reserved
~`NOOP\r\n` when updated priority is the same~

Looking forward to any feedback!

