### PR TITLE
add macros twarnf and twarnerrf for variable arguments

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -38,12 +38,16 @@ make_conn(int fd, char start_state, Tube *use, Tube *watch)
     Conn *c;
 
     c = new(Conn);
-    if (!c) return twarnerr("OOM"), NULL;
+    if (!c) {
+        twarnerr("OOM");
+        return NULL;
+    }
 
     ms_init(&c->watch, (ms_event_fn) on_watch, (ms_event_fn) on_ignore);
     if (!ms_append(&c->watch, watch)) {
         free(c);
-        return twarnerr("OOM"), NULL;
+        twarnerr("OOM");
+        return NULL;
     }
 
     TUBE_ASSIGN(c->use, use);

--- a/dat.h
+++ b/dat.h
@@ -231,10 +231,15 @@ struct Tube {
 };
 
 
-#define twarnerr(fmt, args...) \
-    warnerr("%s:%d in %s: " fmt, __FILE__, __LINE__, __func__, ##args)
-#define twarn(fmt, args...) \
-    warn("%s:%d in %s: " fmt, __FILE__, __LINE__, __func__, ##args)
+#define twarnerr(fmt) \
+    warnerr("%s:%d in %s: " fmt, __FILE__, __LINE__, __func__)
+#define twarnerrf(fmt, ...) \
+    warnerr("%s:%d in %s: " fmt, __FILE__, __LINE__, __func__, __VA_ARGS__)
+
+#define twarn(fmt)  \
+    warn("%s:%d in %s: " fmt, __FILE__, __LINE__, __func__)
+#define twarnf(fmt, ...) \
+    warn("%s:%d in %s: " fmt, __FILE__, __LINE__, __func__,  __VA_ARGS__)
 
 // warnerr prints fmt and the error message based on errno into stderr:
 // "progname: fmt: error message"

--- a/file.c
+++ b/file.c
@@ -443,7 +443,7 @@ filewopen(File *f)
 
     fd = open(f->path, O_WRONLY|O_CREAT, 0400);
     if (fd < 0) {
-        twarnerr("open %s", f->path);
+        twarnerrf("open %s", f->path);
         return;
     }
 
@@ -451,17 +451,17 @@ filewopen(File *f)
     if (r) {
         close(fd);
         errno = r;
-        twarnerr("falloc %s", f->path);
+        twarnerrf("falloc %s", f->path);
         r = unlink(f->path);
         if (r) {
-            twarnerr("unlink %s", f->path);
+            twarnerrf("unlink %s", f->path);
         }
         return;
     }
 
     n = write(fd, &ver, sizeof(int));
     if (n < 0 || (size_t)n < sizeof(int)) {
-        twarnerr("write %s", f->path);
+        twarnerrf("write %s", f->path);
         close(fd);
         return;
     }

--- a/job.c
+++ b/job.c
@@ -54,7 +54,7 @@ rehash(int is_upscaling)
     all_jobs_cap = primes[cur_prime];
     all_jobs = calloc(all_jobs_cap, sizeof(Job *));
     if (!all_jobs) {
-        twarn("Failed to allocate %zu new hash buckets", all_jobs_cap);
+        twarnf("Failed to allocate %zu new hash buckets", all_jobs_cap);
         hash_table_was_oom = 1;
         cur_prime = old_prime;
         all_jobs = old;
@@ -115,7 +115,10 @@ make_job_with_id(uint32 pri, int64 delay, int64 ttr,
     Job *j;
 
     j = allocate_job(body_size);
-    if (!j) return twarn("OOM"), (Job *) 0;
+    if (!j) {
+        twarn("OOM");
+        return (Job *) 0;
+    }
 
     if (id) {
         j->r.id = id;
@@ -195,7 +198,10 @@ job_copy(Job *j)
     if (!j) return NULL;
 
     n = malloc(sizeof(Job) + j->r.body_size);
-    if (!n) return twarn("OOM"), (Job *) 0;
+    if (!n) {
+        twarn("OOM");
+        return (Job *) 0;
+    }
 
     memcpy(n, j, sizeof(Job) + j->r.body_size);
     n->next = n->prev = n; /* not in a linked list */

--- a/main.c
+++ b/main.c
@@ -15,23 +15,23 @@ su(const char *user)
     errno = 0;
     struct passwd *pwent = getpwnam(user);
     if (errno) {
-        twarnerr("getpwnam(\"%s\")", user);
+        twarnerrf("getpwnam(\"%s\")", user);
         exit(32);
     }
     if (!pwent) {
-        twarn("getpwnam(\"%s\"): no such user", user);
+        twarnf("getpwnam(\"%s\"): no such user", user);
         exit(33);
     }
 
     int r = setgid(pwent->pw_gid);
     if (r == -1) {
-        twarnerr("setgid(%d \"%s\")", pwent->pw_gid, user);
+        twarnerrf("setgid(%d \"%s\")", pwent->pw_gid, user);
         exit(34);
     }
 
     r = setuid(pwent->pw_uid);
     if (r == -1) {
-        twarnerr("setuid(%d \"%s\")", pwent->pw_uid, user);
+        twarnerrf("setuid(%d \"%s\")", pwent->pw_uid, user);
         exit(34);
     }
 }
@@ -95,7 +95,7 @@ main(int argc, char **argv)
         // to use the wal directory at a time. So acquire a lock
         // now and never release it.
         if (!waldirlock(&srv.wal)) {
-            twarn("failed to lock wal dir %s", srv.wal.dir);
+            twarnf("failed to lock wal dir %s", srv.wal.dir);
             exit(10);
         }
 

--- a/net.c
+++ b/net.c
@@ -22,7 +22,8 @@ make_server_socket(char *host, char *port)
      * return. */
     r = sd_listen_fds(1);
     if (r < 0) {
-        return twarnerr("sd_listen_fds"), -1;
+        twarnerr("sd_listen_fds");
+        return -1;
     }
     if (r > 0) {
         if (r > 1) {
@@ -49,7 +50,7 @@ make_server_socket(char *host, char *port)
     hints.ai_flags = AI_PASSIVE;
     r = getaddrinfo(host, port, &hints, &airoot);
     if (r != 0) {
-      twarn("getaddrinfo(): %s", gai_strerror(r));
+      twarnf("getaddrinfo(): %s", gai_strerror(r));
       return -1;
     }
 
@@ -77,25 +78,25 @@ make_server_socket(char *host, char *port)
       flags = 1;
       r = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &flags, sizeof flags);
       if (r == -1) {
-        twarnerr("setting SO_REUSEADDR on fd %d", fd);
+        twarnerrf("setting SO_REUSEADDR on fd %d", fd);
         close(fd);
         continue;
       }
       r = setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &flags, sizeof flags);
       if (r == -1) {
-        twarnerr("setting SO_KEEPALIVE on fd %d", fd);
+        twarnerrf("setting SO_KEEPALIVE on fd %d", fd);
         close(fd);
         continue;
       }
       r = setsockopt(fd, SOL_SOCKET, SO_LINGER, &linger, sizeof linger);
       if (r == -1) {
-        twarnerr("setting SO_LINGER on fd %d", fd);
+        twarnerrf("setting SO_LINGER on fd %d", fd);
         close(fd);
         continue;
       }
       r = setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flags, sizeof flags);
       if (r == -1) {
-        twarnerr("setting TCP_NODELAY on fd %d", fd);
+        twarnerrf("setting TCP_NODELAY on fd %d", fd);
         close(fd);
         continue;
       }

--- a/prot.c
+++ b/prot.c
@@ -315,7 +315,7 @@ protrmdirty(Conn *c)
 
 #define reply_msg(c,m) reply((c),(m),CONSTSTRLEN(m),STATE_SENDWORD)
 
-#define reply_serr(c,e) (twarn("server error: %s",(e)),\
+#define reply_serr(c,e) (twarnf("server error: %s",(e)),\
                          reply_msg((c),(e)))
 
 static void
@@ -701,7 +701,7 @@ check_err(Conn *c, const char *s)
     if (errno == EINTR) return;
     if (errno == EWOULDBLOCK) return;
 
-    twarnerr("%s", s);
+    twarnerrf("%s", s);
     c->state = STATE_CLOSE;
     return;
 }
@@ -2046,7 +2046,8 @@ prot_init()
     ms_init(&tubes, NULL, NULL);
 
     TUBE_ASSIGN(default_tube, tube_find_or_make("default"));
-    if (!default_tube) twarn("Out of memory during startup!");
+    if (!default_tube)
+        twarn("Out of memory during startup!");
 }
 
 // For each job in list, inserts the job into the appropriate data
@@ -2081,7 +2082,8 @@ prot_replay(Server *s, Job *list)
             /* fall through */
         default:
             r = enqueue_job(s, j, delay, 0);
-            if (r < 1) twarn("error recovering job %"PRIu64, j->r.id);
+            if (r < 1)
+                twarnf("error recovering job %"PRIu64, j->r.id);
         }
     }
     return 1;

--- a/testserv.c
+++ b/testserv.c
@@ -87,7 +87,7 @@ mustdiallocal(int port)
     // Fix of the benchmarking issue on Linux. See issue #430.
     int flags = 1;
     if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flags, sizeof(int))) {
-        twarnerr("setting TCP_NODELAY on fd %d", fd);
+        twarnerrf("setting TCP_NODELAY on fd %d", fd);
         exit(1);
     }
 
@@ -188,7 +188,7 @@ mustforksrv(void)
         // to use the wal directory at a time. So acquire a lock
         // now and never release it.
         if (!waldirlock(&srv.wal)) {
-            twarn("failed to lock wal dir %s", srv.wal.dir);
+            twarnf("failed to lock wal dir %s", srv.wal.dir);
             exit(10);
         }
 

--- a/tube.c
+++ b/tube.c
@@ -46,7 +46,7 @@ tube_dref(Tube *t)
 {
     if (!t) return;
     if (t->refs < 1)
-        return twarn("refs is zero for tube: %s", t->name);
+        return twarnf("refs is zero for tube: %s", t->name);
 
     --t->refs;
     if (t->refs < 1)

--- a/walg.c
+++ b/walg.c
@@ -459,7 +459,7 @@ walread(Wal *w, Job *list, int min)
 
         fd = open(f->path, O_RDONLY);
         if (fd < 0) {
-            twarnerr("open %s", f->path);
+            twarnerrf("open %s", f->path);
             free(f->path);
             free(f);
             continue;


### PR DESCRIPTION
This patch uses __VA_ARGS__ instead of GNU extentsion.
If there is a need to supply formatting string with argument to twarn*
then functions with suffix "f" must be used.

Fixes #488