### PR TITLE
Revert "make names of warn* functions and macros consistent"

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -38,12 +38,12 @@ make_conn(int fd, char start_state, Tube *use, Tube *watch)
     Conn *c;
 
     c = new(Conn);
-    if (!c) return twarnerr("OOM"), NULL;
+    if (!c) return twarn("OOM"), NULL;
 
     ms_init(&c->watch, (ms_event_fn) on_watch, (ms_event_fn) on_ignore);
     if (!ms_append(&c->watch, watch)) {
         free(c);
-        return twarnerr("OOM"), NULL;
+        return twarn("OOM"), NULL;
     }
 
     TUBE_ASSIGN(c->use, use);

--- a/darwin.c
+++ b/darwin.c
@@ -41,7 +41,7 @@ sockinit(void)
 {
     kq = kqueue();
     if (kq == -1) {
-        twarnerr("kqueue");
+        twarn("kqueue");
         return -1;
     }
     return 0;
@@ -100,7 +100,7 @@ socknext(Socket **s, int64 timeout)
     ts.tv_nsec = timeout % 1000000000;
     r = kevent(kq, NULL, 0, &ev, 1, &ts);
     if (r == -1 && errno != EINTR) {
-        twarnerr("kevent");
+        twarn("kevent");
         return -1;
     }
 

--- a/dat.h
+++ b/dat.h
@@ -231,19 +231,13 @@ struct Tube {
 };
 
 
-#define twarnerr(fmt, args...) \
-    warnerr("%s:%d in %s: " fmt, __FILE__, __LINE__, __func__, ##args)
-#define twarn(fmt, args...) \
-    warn("%s:%d in %s: " fmt, __FILE__, __LINE__, __func__, ##args)
+#define twarn(fmt, args...) warn("%s:%d in %s: " fmt, \
+                                 __FILE__, __LINE__, __func__, ##args)
+#define twarnx(fmt, args...) warnx("%s:%d in %s: " fmt, \
+                                   __FILE__, __LINE__, __func__, ##args)
 
-// warnerr prints fmt and the error message based on errno into stderr:
-// "progname: fmt: error message"
-void warnerr(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-
-// warn prints fmt into stderr:
-// "progname: fmt"
 void warn(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-
+void warnx(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 char* fmtalloc(char *fmt, ...) __attribute__((format(printf, 1, 2)));
 void* zalloc(int n);
 #define new(T) zalloc(sizeof(T))
@@ -254,8 +248,7 @@ extern const char *progname;
 int64 nanoseconds(void);
 int   rawfalloc(int fd, int len);
 
-#define make_job(pri,delay,ttr,body_size,tube) \
-    make_job_with_id(pri,delay,ttr,body_size,tube,0)
+#define make_job(pri,delay,ttr,body_size,tube) make_job_with_id(pri,delay,ttr,body_size,tube,0)
 
 Job *allocate_job(int body_size);
 Job *make_job_with_id(uint pri, int64 delay, int64 ttr,

--- a/file.c
+++ b/file.c
@@ -124,7 +124,7 @@ fileread(File *f, Job *list)
         return err;
     }
 
-    warn("%s: unknown version: %d", f->path, v);
+    warnx("%s: unknown version: %d", f->path, v);
     return 1;
 }
 
@@ -144,7 +144,7 @@ readrec(File *f, Job *l, int *err)
 
     r = read(f->fd, &namelen, sizeof(int));
     if (r == -1) {
-        twarnerr("read");
+        twarn("read");
         warnpos(f, 0, "error");
         *err = 1;
         return 0;
@@ -274,7 +274,7 @@ readrec5(File *f, Job *l, int *err)
 
     r = read(f->fd, &namelen, sizeof(namelen));
     if (r == -1) {
-        twarnerr("read");
+        twarn("read");
         warnpos(f, 0, "error");
         *err = 1;
         return 0;
@@ -403,7 +403,7 @@ readfull(File *f, void *c, int n, int *err, char *desc)
 
     r = read(f->fd, c, n);
     if (r == -1) {
-        twarnerr("read");
+        twarn("read");
         warnpos(f, 0, "error reading %s", desc);
         *err = 1;
         return 0;
@@ -443,7 +443,7 @@ filewopen(File *f)
 
     fd = open(f->path, O_WRONLY|O_CREAT, 0400);
     if (fd < 0) {
-        twarnerr("open %s", f->path);
+        twarn("open %s", f->path);
         return;
     }
 
@@ -451,17 +451,17 @@ filewopen(File *f)
     if (r) {
         close(fd);
         errno = r;
-        twarnerr("falloc %s", f->path);
+        twarn("falloc %s", f->path);
         r = unlink(f->path);
         if (r) {
-            twarnerr("unlink %s", f->path);
+            twarn("unlink %s", f->path);
         }
         return;
     }
 
     n = write(fd, &ver, sizeof(int));
     if (n < 0 || (size_t)n < sizeof(int)) {
-        twarnerr("write %s", f->path);
+        twarn("write %s", f->path);
         close(fd);
         return;
     }
@@ -481,7 +481,7 @@ filewrite(File *f, Job *j, void *buf, int len)
 
     r = write(f->fd, buf, len);
     if (r != len) {
-        twarnerr("write");
+        twarn("write");
         return 0;
     }
 
@@ -535,7 +535,7 @@ filewclose(File *f)
     if (f->free) {
         errno = 0;
         if (ftruncate(f->fd, f->w->filesize - f->free) != 0) {
-            twarnerr("ftruncate");
+            twarn("ftruncate");
         }
     }
     close(f->fd);

--- a/job.c
+++ b/job.c
@@ -54,7 +54,7 @@ rehash(int is_upscaling)
     all_jobs_cap = primes[cur_prime];
     all_jobs = calloc(all_jobs_cap, sizeof(Job *));
     if (!all_jobs) {
-        twarn("Failed to allocate %zu new hash buckets", all_jobs_cap);
+        twarnx("Failed to allocate %zu new hash buckets", all_jobs_cap);
         hash_table_was_oom = 1;
         cur_prime = old_prime;
         all_jobs = old;
@@ -96,7 +96,7 @@ allocate_job(int body_size)
 
     j = malloc(sizeof(Job) + body_size);
     if (!j) {
-        twarn("OOM");
+        twarnx("OOM");
         return (Job *) 0;
     }
 
@@ -115,7 +115,7 @@ make_job_with_id(uint32 pri, int64 delay, int64 ttr,
     Job *j;
 
     j = allocate_job(body_size);
-    if (!j) return twarn("OOM"), (Job *) 0;
+    if (!j) return twarnx("OOM"), (Job *) 0;
 
     if (id) {
         j->r.id = id;
@@ -195,7 +195,7 @@ job_copy(Job *j)
     if (!j) return NULL;
 
     n = malloc(sizeof(Job) + j->r.body_size);
-    if (!n) return twarn("OOM"), (Job *) 0;
+    if (!n) return twarnx("OOM"), (Job *) 0;
 
     memcpy(n, j, sizeof(Job) + j->r.body_size);
     n->next = n->prev = n; /* not in a linked list */

--- a/linux.c
+++ b/linux.c
@@ -31,7 +31,7 @@ sockinit(void)
 {
     epfd = epoll_create(1);
     if (epfd == -1) {
-        twarnerr("epoll_create");
+        twarn("epoll_create");
         return -1;
     }
     return 0;
@@ -78,7 +78,7 @@ socknext(Socket **s, int64 timeout)
 
     r = epoll_wait(epfd, &ev, 1, (int)(timeout/1000000));
     if (r == -1 && errno != EINTR) {
-        twarnerr("epoll_wait");
+        twarn("epoll_wait");
         exit(1);
     }
 

--- a/main.c
+++ b/main.c
@@ -15,23 +15,23 @@ su(const char *user)
     errno = 0;
     struct passwd *pwent = getpwnam(user);
     if (errno) {
-        twarnerr("getpwnam(\"%s\")", user);
+        twarn("getpwnam(\"%s\")", user);
         exit(32);
     }
     if (!pwent) {
-        twarn("getpwnam(\"%s\"): no such user", user);
+        twarnx("getpwnam(\"%s\"): no such user", user);
         exit(33);
     }
 
     int r = setgid(pwent->pw_gid);
     if (r == -1) {
-        twarnerr("setgid(%d \"%s\")", pwent->pw_gid, user);
+        twarn("setgid(%d \"%s\")", pwent->pw_gid, user);
         exit(34);
     }
 
     r = setuid(pwent->pw_uid);
     if (r == -1) {
-        twarnerr("setuid(%d \"%s\")", pwent->pw_uid, user);
+        twarn("setuid(%d \"%s\")", pwent->pw_uid, user);
         exit(34);
     }
 }
@@ -45,20 +45,20 @@ set_sig_handlers()
     sa.sa_flags = 0;
     int r = sigemptyset(&sa.sa_mask);
     if (r == -1) {
-        twarnerr("sigemptyset()");
+        twarn("sigemptyset()");
         exit(111);
     }
 
     r = sigaction(SIGPIPE, &sa, 0);
     if (r == -1) {
-        twarnerr("sigaction(SIGPIPE)");
+        twarn("sigaction(SIGPIPE)");
         exit(111);
     }
 
     sa.sa_handler = enter_drain_mode;
     r = sigaction(SIGUSR1, &sa, 0);
     if (r == -1) {
-        twarnerr("sigaction(SIGUSR1)");
+        twarn("sigaction(SIGUSR1)");
         exit(111);
     }
 }
@@ -78,7 +78,7 @@ main(int argc, char **argv)
 
     int r = make_server_socket(srv.addr, srv.port);
     if (r == -1) {
-        twarn("make_server_socket()");
+        twarnx("make_server_socket()");
         exit(111);
     }
 
@@ -95,7 +95,7 @@ main(int argc, char **argv)
         // to use the wal directory at a time. So acquire a lock
         // now and never release it.
         if (!waldirlock(&srv.wal)) {
-            twarn("failed to lock wal dir %s", srv.wal.dir);
+            twarnx("failed to lock wal dir %s", srv.wal.dir);
             exit(10);
         }
 
@@ -104,7 +104,7 @@ main(int argc, char **argv)
         walinit(&srv.wal, &list);
         r = prot_replay(&srv, &list);
         if (!r) {
-            twarn("failed to replay log");
+            twarnx("failed to replay log");
             exit(1);
         }
     }

--- a/net.c
+++ b/net.c
@@ -22,22 +22,22 @@ make_server_socket(char *host, char *port)
      * return. */
     r = sd_listen_fds(1);
     if (r < 0) {
-        return twarnerr("sd_listen_fds"), -1;
+        return twarn("sd_listen_fds"), -1;
     }
     if (r > 0) {
         if (r > 1) {
-            twarn("inherited more than one listen socket;"
+            twarnx("inherited more than one listen socket;"
                    " ignoring all but the first");
         }
         fd = SD_LISTEN_FDS_START;
         r = sd_is_socket_inet(fd, 0, SOCK_STREAM, 1, 0);
         if (r < 0) {
             errno = -r;
-            twarnerr("sd_is_socket_inet");
+            twarn("sd_is_socket_inet");
             return -1;
         }
         if (!r) {
-            twarn("inherited fd is not a TCP listen socket");
+            twarnx("inherited fd is not a TCP listen socket");
             return -1;
         }
         return fd;
@@ -49,27 +49,27 @@ make_server_socket(char *host, char *port)
     hints.ai_flags = AI_PASSIVE;
     r = getaddrinfo(host, port, &hints, &airoot);
     if (r != 0) {
-      twarn("getaddrinfo(): %s", gai_strerror(r));
+      twarnx("getaddrinfo(): %s", gai_strerror(r));
       return -1;
     }
 
     for(ai = airoot; ai; ai = ai->ai_next) {
       fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
       if (fd == -1) {
-        twarnerr("socket()");
+        twarn("socket()");
         continue;
       }
 
       flags = fcntl(fd, F_GETFL, 0);
       if (flags < 0) {
-        twarnerr("getting flags");
+        twarn("getting flags");
         close(fd);
         continue;
       }
 
       r = fcntl(fd, F_SETFL, flags | O_NONBLOCK);
       if (r == -1) {
-        twarnerr("setting O_NONBLOCK");
+        twarn("setting O_NONBLOCK");
         close(fd);
         continue;
       }
@@ -77,32 +77,32 @@ make_server_socket(char *host, char *port)
       flags = 1;
       r = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &flags, sizeof flags);
       if (r == -1) {
-        twarnerr("setting SO_REUSEADDR on fd %d", fd);
+        twarn("setting SO_REUSEADDR on fd %d", fd);
         close(fd);
         continue;
       }
       r = setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &flags, sizeof flags);
       if (r == -1) {
-        twarnerr("setting SO_KEEPALIVE on fd %d", fd);
+        twarn("setting SO_KEEPALIVE on fd %d", fd);
         close(fd);
         continue;
       }
       r = setsockopt(fd, SOL_SOCKET, SO_LINGER, &linger, sizeof linger);
       if (r == -1) {
-        twarnerr("setting SO_LINGER on fd %d", fd);
+        twarn("setting SO_LINGER on fd %d", fd);
         close(fd);
         continue;
       }
       r = setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flags, sizeof flags);
       if (r == -1) {
-        twarnerr("setting TCP_NODELAY on fd %d", fd);
+        twarn("setting TCP_NODELAY on fd %d", fd);
         close(fd);
         continue;
       }
 
       r = bind(fd, ai->ai_addr, ai->ai_addrlen);
       if (r == -1) {
-        twarnerr("bind()");
+        twarn("bind()");
         close(fd);
         continue;
       }
@@ -132,7 +132,7 @@ make_server_socket(char *host, char *port)
 
       r = listen(fd, 1024);
       if (r == -1) {
-        twarnerr("listen()");
+        twarn("listen()");
         close(fd);
         continue;
       }

--- a/serv.c
+++ b/serv.c
@@ -19,7 +19,7 @@ srvserve(Server *s)
     int64 period;
 
     if (sockinit() == -1) {
-        twarn("sockinit");
+        twarnx("sockinit");
         exit(1);
     }
 
@@ -30,13 +30,13 @@ srvserve(Server *s)
 
     r = listen(s->sock.fd, 1024);
     if (r == -1) {
-        twarnerr("listen");
+        twarn("listen");
         return;
     }
 
     r = sockwant(&s->sock, 'r');
     if (r == -1) {
-        twarnerr("sockwant");
+        twarn("sockwant");
         exit(2);
     }
 
@@ -46,7 +46,7 @@ srvserve(Server *s)
 
         int rw = socknext(&sock, period);
         if (rw == -1) {
-            twarn("socknext");
+            twarnx("socknext");
             exit(1);
         }
 

--- a/sunos.c
+++ b/sunos.c
@@ -35,7 +35,7 @@ sockinit(void)
 {
     portfd = port_create();
     if (portfd == -1) {
-        twarnerr("port_create");
+        twarn("port_create");
         return -1;
     }
     return 0;
@@ -86,7 +86,7 @@ socknext(Socket **s, int64 timeout)
     ts.tv_nsec = timeout % 1000000000;
     r = port_getn(portfd, &pe, 1, &n, &ts);
     if (r == -1 && errno != ETIME && errno != EINTR) {
-        twarnerr("port_getn");
+        twarn("port_getn");
         return -1;
     }
 

--- a/testserv.c
+++ b/testserv.c
@@ -47,7 +47,7 @@ muststart(char *a0, char *a1, char *a2, char *a3, char *a4)
 {
     srvpid = fork();
     if (srvpid < 0) {
-        twarnerr("fork");
+        twarn("fork");
         exit(1);
     }
 
@@ -74,26 +74,26 @@ mustdiallocal(int port)
     int r = inet_aton("127.0.0.1", &addr.sin_addr);
     if (!r) {
         errno = EINVAL;
-        twarnerr("inet_aton");
+        twarn("inet_aton");
         exit(1);
     }
 
     int fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd == -1) {
-        twarnerr("socket");
+        twarn("socket");
         exit(1);
     }
 
     // Fix of the benchmarking issue on Linux. See issue #430.
     int flags = 1;
     if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flags, sizeof(int))) {
-        twarnerr("setting TCP_NODELAY on fd %d", fd);
+        twarn("setting TCP_NODELAY on fd %d", fd);
         exit(1);
     }
 
     r = connect(fd, (struct sockaddr *)&addr, sizeof addr);
     if (r == -1) {
-        twarnerr("connect");
+        twarn("connect");
         exit(1);
     }
 
@@ -115,7 +115,7 @@ set_sig_handler()
     sa.sa_flags = 0;
     int r = sigemptyset(&sa.sa_mask);
     if (r == -1) {
-        twarnerr("sigemptyset()");
+        twarn("sigemptyset()");
         exit(111);
     }
 
@@ -123,7 +123,7 @@ set_sig_handler()
     sa.sa_handler = exit_process;
     r = sigaction(SIGTERM, &sa, 0);
     if (r == -1) {
-        twarnerr("sigaction(SIGTERM)");
+        twarn("sigaction(SIGTERM)");
         exit(111);
     }
 }
@@ -167,7 +167,7 @@ mustforksrv(void)
     int port = ntohs(addr.sin_port);
     srvpid = fork();
     if (srvpid < 0) {
-        twarnerr("fork");
+        twarn("fork");
         exit(1);
     }
 
@@ -188,7 +188,7 @@ mustforksrv(void)
         // to use the wal directory at a time. So acquire a lock
         // now and never release it.
         if (!waldirlock(&srv.wal)) {
-            twarn("failed to lock wal dir %s", srv.wal.dir);
+            twarnx("failed to lock wal dir %s", srv.wal.dir);
             exit(10);
         }
 
@@ -200,7 +200,7 @@ mustforksrv(void)
         walinit(&srv.wal, &list);
         int ok = prot_replay(&srv, &list);
         if (!ok) {
-            twarn("failed to replay log");
+            twarnx("failed to replay log");
             exit(11);
         }
     }
@@ -307,7 +307,7 @@ filesize(char *path)
 
     int r = stat(path, &s);
     if (r == -1) {
-        twarnerr("stat");
+        twarn("stat");
         exit(1);
     }
     return s.st_size;

--- a/time.c
+++ b/time.c
@@ -10,7 +10,7 @@ nanoseconds(void)
     struct timeval tv;
 
     r = gettimeofday(&tv, 0);
-    if (r != 0) return warn("gettimeofday"), -1; // can't happen
+    if (r != 0) return warnx("gettimeofday"), -1; // can't happen
 
     return ((int64)tv.tv_sec)*1000000000 + ((int64)tv.tv_usec)*1000;
 }

--- a/tube.c
+++ b/tube.c
@@ -16,7 +16,7 @@ make_tube(const char *name)
     t->name[MAX_TUBE_NAME_LEN - 1] = '\0';
     strncpy(t->name, name, MAX_TUBE_NAME_LEN - 1);
     if (t->name[MAX_TUBE_NAME_LEN - 1] != '\0')
-        twarn("truncating tube name");
+        twarnx("truncating tube name");
 
     t->ready.less = job_pri_less;
     t->delay.less = job_delay_less;
@@ -46,7 +46,7 @@ tube_dref(Tube *t)
 {
     if (!t) return;
     if (t->refs < 1)
-        return twarn("refs is zero for tube: %s", t->name);
+        return twarnx("refs is zero for tube: %s", t->name);
 
     --t->refs;
     if (t->refs < 1)

--- a/util.c
+++ b/util.c
@@ -10,40 +10,37 @@
 const char *progname;
 
 static void
-_warnerr(const char *err, const char *fmt, va_list args)
+vwarnx(const char *err, const char *fmt, va_list args)
 __attribute__((format(printf, 2, 0)));
 
-// _warnerr prints formatted text prefixed by progname into stderr.
-// If err is not NULL, it is printed at last.
 static void
-_warnerr(const char *err, const char *fmt, va_list args)
+vwarnx(const char *err, const char *fmt, va_list args)
 {
     fprintf(stderr, "%s: ", progname);
     if (fmt) {
         vfprintf(stderr, fmt, args);
-        if (err)
-            fprintf(stderr, ": %s", err);
+        if (err) fprintf(stderr, ": %s", err);
     }
     fputc('\n', stderr);
 }
 
 void
-warnerr(const char *fmt, ...)
+warn(const char *fmt, ...)
 {
     char *err = strerror(errno); /* must be done first thing */
     va_list args;
 
     va_start(args, fmt);
-    _warnerr(err, fmt, args);
+    vwarnx(err, fmt, args);
     va_end(args);
 }
 
 void
-warn(const char *fmt, ...)
+warnx(const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    _warnerr(NULL, fmt, args);
+    vwarnx(NULL, fmt, args);
     va_end(args);
 }
 
@@ -90,7 +87,7 @@ static void
 warn_systemd_ignored_option(char *opt, char *arg)
 {
     if (sd_listen_fds(0) > 0) {
-        warn("inherited listen fd; ignoring option: %s %s", opt, arg);
+        warnx("inherited listen fd; ignoring option: %s %s", opt, arg);
     }
 }
 
@@ -129,7 +126,7 @@ static char *flagusage(char *flag) __attribute__ ((noreturn));
 static char *
 flagusage(char *flag)
 {
-    warn("flag requires an argument: %s", flag);
+    warnx("flag requires an argument: %s", flag);
     usage(5);
 }
 
@@ -142,7 +139,7 @@ parse_size_t(char *str)
 
     r = sscanf(str, "%zu%c", &size, &x);
     if (1 != r) {
-        warn("invalid size: %s", str);
+        warnx("invalid size: %s", str);
         usage(5);
     }
     return size;
@@ -170,7 +167,7 @@ optparse(Server *s, char **argv)
                 case 'z':
                     job_data_size_limit = parse_size_t(EARGF(flagusage("-z")));
                     if (job_data_size_limit > JOB_DATA_SIZE_LIMIT_MAX) {
-                        warn("maximum job size was set to %d", JOB_DATA_SIZE_LIMIT_MAX);
+                        warnx("maximum job size was set to %d", JOB_DATA_SIZE_LIMIT_MAX);
                         job_data_size_limit = JOB_DATA_SIZE_LIMIT_MAX;
                     }
                     break;
@@ -207,13 +204,13 @@ optparse(Server *s, char **argv)
                     verbose++;
                     break;
                 default:
-                    warn("unknown flag: %s", arg-2);
+                    warnx("unknown flag: %s", arg-2);
                     usage(5);
             }
         }
     }
     if (arg) {
-        warn("unknown argument: %s", arg-1);
+        warnx("unknown argument: %s", arg-1);
         usage(5);
     }
 }

--- a/walg.c
+++ b/walg.c
@@ -78,7 +78,7 @@ usenext(Wal *w)
 
     f = w->cur;
     if (!f->next) {
-        twarn("there is no next wal file");
+        twarnx("there is no next wal file");
         return 0;
     }
 
@@ -130,7 +130,7 @@ moveone(Wal *w)
     j = w->head->jlist.fnext;
     if (!j || j == &w->head->jlist) {
         // head holds no jlist; can't happen
-        twarn("head holds no jlist");
+        twarnx("head holds no jlist");
         return;
     }
 
@@ -165,7 +165,7 @@ walsync(Wal *w)
     if (w->wantsync && now >= w->lastsync+w->syncrate) {
         w->lastsync = now;
         if (fsync(w->cur->fd) == -1) {
-            twarnerr("fsync");
+            twarn("fsync");
         }
     }
 }
@@ -216,13 +216,13 @@ makenextfile(Wal *w)
 
     f = new(File);
     if (!f) {
-        twarn("OOM");
+        twarnx("OOM");
         return 0;
     }
 
     if (!fileinit(f, w, w->next)) {
         free(f);
-        twarn("OOM");
+        twarnx("OOM");
         return 0;
     }
 
@@ -286,7 +286,7 @@ balancerest(Wal *w, File *b, int n)
     }
 
     if (needfree(w, r) != r) {
-        twarn("needfree");
+        twarnx("needfree");
         return 0;
     }
     moveresv(w->tail, b, r);
@@ -316,7 +316,7 @@ balance(Wal *w, int n)
 
         r = needfree(w, m);
         if (r != m) {
-            twarn("needfree");
+            twarnx("needfree");
             return 0;
         }
 
@@ -347,7 +347,7 @@ reserve(Wal *w, int n)
 
     r = needfree(w, n);
     if (r != n) {
-        twarn("needfree");
+        twarnx("needfree");
         return 0;
     }
 
@@ -409,7 +409,7 @@ waldirlock(Wal *w)
 
     path_length = strlen(w->dir) + strlen("/lock") + 1;
     if ((path = malloc(path_length)) == NULL) {
-        twarnerr("malloc");
+        twarn("malloc");
         return 0;
     }
     r = snprintf(path, path_length, "%s/lock", w->dir);
@@ -417,7 +417,7 @@ waldirlock(Wal *w)
     fd = open(path, O_WRONLY|O_CREAT, 0600);
     free(path);
     if (fd == -1) {
-        twarnerr("open");
+        twarn("open");
         return 0;
     }
 
@@ -427,7 +427,7 @@ waldirlock(Wal *w)
     lk.l_len = 0;
     r = fcntl(fd, F_SETLK, &lk);
     if (r) {
-        twarnerr("fcntl");
+        twarn("fcntl");
         return 0;
     }
 
@@ -447,19 +447,19 @@ walread(Wal *w, Job *list, int min)
     for (i = min; i < w->next; i++) {
         f = new(File);
         if (!f) {
-            twarn("OOM");
+            twarnx("OOM");
             exit(1);
         }
 
         if (!fileinit(f, w, i)) {
             free(f);
-            twarn("OOM");
+            twarnx("OOM");
             exit(1);
         }
 
         fd = open(f->path, O_RDONLY);
         if (fd < 0) {
-            twarnerr("open %s", f->path);
+            twarn("open %s", f->path);
             free(f->path);
             free(f);
             continue;
@@ -472,8 +472,8 @@ walread(Wal *w, Job *list, int min)
     }
 
     if (err) {
-        warn("Errors reading one or more WAL files.");
-        warn("Continuing. You may be missing data.");
+        warnx("Errors reading one or more WAL files.");
+        warnx("Continuing. You may be missing data.");
     }
 }
 
@@ -488,7 +488,7 @@ walinit(Wal *w, Job *list)
 
     // first writable file
     if (!makenextfile(w)) {
-        twarn("makenextfile");
+        twarnx("makenextfile");
         exit(1);
     }
 


### PR DESCRIPTION
This reverts commit c6157f701ca83ed5d5194a53ec8b72c99aa503a9.