### PR TITLE
fix ternary operators to not use GNU extension

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -175,7 +175,7 @@ connsoonestjob(Conn *c)
 
     if (soonest == NULL) {
         for (j = c->reserved_jobs.next; j != &c->reserved_jobs; j = j->next) {
-            if (j->r.deadline_at <= (soonest ? : j)->r.deadline_at)
+            if (j->r.deadline_at <= (soonest ? soonest : j)->r.deadline_at)
                 soonest = j;
         }
     }

--- a/ms.c
+++ b/ms.c
@@ -16,7 +16,9 @@ static void
 grow(Ms *a)
 {
     void **nitems;
-    size_t ncap = (a->cap << 1) ? : 1;
+    size_t ncap = a->cap << 1;
+    if (!ncap)
+        ncap = 1;
 
     nitems = malloc(ncap * sizeof(void *));
     if (!nitems)

--- a/prot.c
+++ b/prot.c
@@ -1364,11 +1364,16 @@ dispatch_cmd(Conn *c)
             return reply_msg(c, MSG_BAD_FORMAT);
         op_ct[type]++;
 
-        j = job_find(id);
-        j = remove_reserved_job(c, j) ? :
-            remove_ready_job(j) ? :
-            remove_buried_job(j) ? :
-            remove_delayed_job(j);
+        {
+            Job *jf = job_find(id);
+            j = remove_reserved_job(c, jf);
+            if (!j)
+                j = remove_ready_job(jf);
+            if (!j)
+                j = remove_buried_job(jf);
+            if (!j)
+                j = remove_delayed_job(jf);
+        }
 
         if (!j)
             return reply_msg(c, MSG_NOTFOUND);

--- a/testserv.c
+++ b/testserv.c
@@ -673,6 +673,24 @@ cttest_delete_ready()
 }
 
 void
+cttest_delete_reserved_by_other()
+{
+    port = SERVER();
+    fd = mustdiallocal(port);
+    mustsend(fd, "put 0 0 1 1\r\n");
+    mustsend(fd, "a\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
+
+    int o = mustdiallocal(port);
+    mustsend(o, "reserve\r\n");
+    ckresp(o, "RESERVED 1 1\r\n");
+    ckresp(o, "a\r\n");
+
+    mustsend(fd, "delete 1\r\n");
+    ckresp(fd, "NOT_FOUND\r\n");
+}
+
+void
 cttest_delete_bad_format()
 {
     port = SERVER();

--- a/tube.c
+++ b/tube.c
@@ -95,6 +95,9 @@ tube_find(const char *name)
 Tube *
 tube_find_or_make(const char *name)
 {
-    return tube_find(name) ? : make_and_insert_tube(name);
+    Tube *t = tube_find(name);
+    if (t)
+        return t;
+    return make_and_insert_tube(name);
 }
 


### PR DESCRIPTION
Discovered by -std=c99 -pedantic