### PR TITLE
refactor the code controlling events for sockets

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -138,16 +138,6 @@ conntickat(Conn *c)
 }
 
 
-// TODO: remove this function by inlining its content into 3 callees places.
-// Reason: conn.c does not use rw anywhere in this file.
-void
-connwant(Conn *c, int rw)
-{
-    c->rw = rw;
-    connsched(c);
-}
-
-
 // Remove c from the c->srv heap and reschedule it using the value
 // returned by conntickat if there is an outstanding timeout in the c.
 void

--- a/dat.h
+++ b/dat.h
@@ -368,7 +368,6 @@ struct Conn {
 };
 int  conn_less(void *ca, void *cb);
 void conn_setpos(void *c, size_t i);
-void connwant(Conn *c, int rw);
 void connsched(Conn *c);
 void connclose(Conn *c);
 void connsetproducer(Conn *c);


### PR DESCRIPTION
The name "dirty" did not reveal the purpose of the variable.
I've renamed it to "epollq".

I have removed connwant() and moved its functionality into introduced
function epollq_add(). This function adds a connection as pending for
polling change. protrmdirty() was renamed to epollq_rmconn().
update_conns() was renamed to epollq_apply().

I added a test checking the "quit" command.

Fixes #524

