### PR TITLE
bracket with error-checking all the calls to close() on files

### DIFF
--- a/file.c
+++ b/file.c
@@ -450,7 +450,8 @@ filewopen(File *f)
 
     r = falloc(fd, f->w->filesize);
     if (r) {
-        close(fd);
+        if (close(fd) == -1)
+            twarn("close");
         errno = r;
         twarn("falloc %s", f->path);
         r = unlink(f->path);
@@ -463,7 +464,8 @@ filewopen(File *f)
     n = write(fd, &ver, sizeof(int));
     if (n < 0 || (size_t)n < sizeof(int)) {
         twarn("write %s", f->path);
-        close(fd);
+        if (close(fd) == -1)
+            twarn("close");
         return;
     }
 
@@ -539,7 +541,8 @@ filewclose(File *f)
             twarn("ftruncate");
         }
     }
-    close(f->fd);
+    if (close(f->fd) == -1)
+        twarn("close");
     f->iswopen = 0;
     filedecref(f);
 }

--- a/walg.c
+++ b/walg.c
@@ -465,7 +465,8 @@ walread(Wal *w, Job *list, int min)
         f->fd = fd;
         fileadd(f, w);
         err |= fileread(f, list);
-        close(fd);
+        if (close(fd) == -1)
+            twarn("close");
     }
 
     if (err) {


### PR DESCRIPTION
close() on a file can fail.