### PR TITLE
Free placeholder stats/peek job by checking state in connclose

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -226,7 +226,7 @@ connclose(Conn *c)
     job_free(c->in_job);
 
     /* was this a peek or stats command? */
-    if (c->out_job && !c->out_job->r.id) job_free(c->out_job);
+    if (c->out_job && c->out_job->r.state == Copy) job_free(c->out_job);
 
     c->in_job = c->out_job = NULL;
     c->in_job_read = 0;


### PR DESCRIPTION
"Placeholder" jobs used to return info (stats, list tube) have their state set to `Copy`, as well as copied jobs for peek commands. Consistent with https://github.com/beanstalkd/beanstalkd/blob/master/prot.c#L1859

There could also be a potential memory leak if a connection is closed with a pending peek job copy (where `c->out_job->r.id` is set).

Sidenote: should there be another enum constant added to better indicate the state of these fake jobs - rather than `Copy`?