### PR TITLE
factor out the code acquiring the wal dir

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -478,5 +478,6 @@ struct Server {
     // Connections that must produce deadline or timeout, ordered by the time.
     Heap   conns;
 };
+void srv_acquire_wal(Server *s);
 void srvserve(Server *s);
 void srvaccept(Server *s, int ev);

--- a/main.c
+++ b/main.c
@@ -108,25 +108,7 @@ main(int argc, char **argv)
         su(srv.user);
     set_sig_handlers();
 
-    if (srv.wal.use) {
-        // We want to make sure that only one beanstalkd tries
-        // to use the wal directory at a time. So acquire a lock
-        // now and never release it.
-        if (!waldirlock(&srv.wal)) {
-            twarnx("failed to lock wal dir %s", srv.wal.dir);
-            exit(10);
-        }
-
-        Job list = {.prev=NULL, .next=NULL};
-        list.prev = list.next = &list;
-        walinit(&srv.wal, &list);
-        r = prot_replay(&srv, &list);
-        if (!r) {
-            twarnx("failed to replay log");
-            exit(1);
-        }
-    }
-
+    srv_acquire_wal(&srv);
     srvserve(&srv);
     exit(0);
 }

--- a/serv.c
+++ b/serv.c
@@ -10,6 +10,29 @@ struct Server srv = {
     },
 };
 
+// srv_acquire_wal tries to lock the wal dir specified by s->wal and
+// replay entries from it to initialize the s state with jobs.
+// On errors it exits from the program.
+void srv_acquire_wal(Server *s) {
+    if (s->wal.use) {
+        // We want to make sure that only one beanstalkd tries
+        // to use the wal directory at a time. So acquire a lock
+        // now and never release it.
+        if (!waldirlock(&s->wal)) {
+            twarnx("failed to lock wal dir %s", s->wal.dir);
+            exit(10);
+        }
+
+        Job list = {.prev=NULL, .next=NULL};
+        list.prev = list.next = &list;
+        walinit(&s->wal, &list);
+        int ok = prot_replay(s, &list);
+        if (!ok) {
+            twarnx("failed to replay log");
+            exit(1);
+        }
+    }
+}
 
 void
 srvserve(Server *s)

--- a/testserv.c
+++ b/testserv.c
@@ -183,27 +183,7 @@ mustforksrv(void)
     set_sig_handler();
     prot_init();
 
-    if (srv.wal.use) {
-        // We want to make sure that only one beanstalkd tries
-        // to use the wal directory at a time. So acquire a lock
-        // now and never release it.
-        if (!waldirlock(&srv.wal)) {
-            twarnx("failed to lock wal dir %s", srv.wal.dir);
-            exit(10);
-        }
-
-        Job list = {
-            .prev = NULL,
-            .next = NULL,
-        };
-        list.prev = list.next = &list;
-        walinit(&srv.wal, &list);
-        int ok = prot_replay(&srv, &list);
-        if (!ok) {
-            twarnx("failed to replay log");
-            exit(11);
-        }
-    }
+    srv_acquire_wal(&srv);
 
     srvserve(&srv); /* does not return */
     exit(1); /* satisfy the compiler */


### PR DESCRIPTION
This removed duplication of code between the testing and server sites.
Also it enables adding specialized function for forking the server in
tests, namely testing of AF_UNIX in #150.