### PR TITLE
rename delay_q_peek() to soonest_delayed_job()

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -203,7 +203,13 @@ struct Jobrec {
     int64  ttr;
     int32  body_size;
     int64  created_at;
+
+    // deadline_at is a timestamp, in nsec, that points to:
+    // * time when job will become ready for delayed job,
+    // * time when TTR is about to expire for reserved job,
+    // * undefined otherwise.
     int64  deadline_at;
+
     uint32 reserve_ct;
     uint32 timeout_ct;
     uint32 release_ct;
@@ -241,8 +247,14 @@ struct Tube {
     struct stats stat;
     uint using_ct;
     uint watching_ct;
+
+    // pause is set to the duration of the current pause, otherwise 0, in nsec.
     int64 pause;
+
+    // dealine_at is a timestamp when to unpause the tube, in nsec.
+    // TODO: rename to unpause_at
     int64 deadline_at;
+
     Job buried;                 // linked list header
 };
 

--- a/testserv.c
+++ b/testserv.c
@@ -871,6 +871,44 @@ cttest_small_delay()
 }
 
 void
+cttest_delayed_to_ready()
+{
+    int port = SERVER();
+    int fd = mustdiallocal(port);
+    mustsend(fd, "put 0 1 1 0\r\n");
+    mustsend(fd, "\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
+
+    mustsend(fd, "stats-tube default\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\ncurrent-jobs-ready: 0\n");
+
+    mustsend(fd, "stats-tube default\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\ncurrent-jobs-delayed: 1\n");
+
+    mustsend(fd, "stats-tube default\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\ntotal-jobs: 1\n");
+
+    usleep(1010000); // 1.01 sec
+
+    // check that after 1 sec the delayed job is ready again
+
+    mustsend(fd, "stats-tube default\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\ncurrent-jobs-ready: 1\n");
+
+    mustsend(fd, "stats-tube default\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\ncurrent-jobs-delayed: 0\n");
+
+    mustsend(fd, "stats-tube default\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\ntotal-jobs: 1\n");
+}
+
+void
 cttest_statsjob_ck_format()
 {
     int port = SERVER();


### PR DESCRIPTION
I have removed the delay_q_take() function because it had
only one line added compared to delay_q_peek(). That line
was put in place. As a result prottick() became easier to read.