### PR TITLE
fix the way tube is truncated

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -47,7 +47,7 @@ typedef int(FAlloc)(int, int);
 // A command can be at most LINE_BUF_SIZE chars, including "\r\n". This value
 // MUST be enough to hold the longest possible command ("pause-tube a{200} 4294967295\r\n")
 // or reply line ("USING a{200}\r\n").
-#define LINE_BUF_SIZE 224
+#define LINE_BUF_SIZE (11 + MAX_TUBE_NAME_LEN + 12)
 
 #define min(a,b) ((a)<(b)?(a):(b))
 

--- a/prot.c
+++ b/prot.c
@@ -1633,7 +1633,7 @@ dispatch_cmd(Conn *c)
 
     case OP_STATS_TUBE:
         name = c->cmd + CMD_STATS_TUBE_LEN;
-        if (!name_is_ok(name, 200)) {
+        if (!name_is_ok(name, MAX_TUBE_NAME_LEN - 1)) {
             reply_msg(c, MSG_BAD_FORMAT);
             return;
         }
@@ -1680,7 +1680,7 @@ dispatch_cmd(Conn *c)
 
     case OP_USE:
         name = c->cmd + CMD_USE_LEN;
-        if (!name_is_ok(name, 200)) {
+        if (!name_is_ok(name, MAX_TUBE_NAME_LEN - 1)) {
             reply_msg(c, MSG_BAD_FORMAT);
             return;
         }
@@ -1702,7 +1702,7 @@ dispatch_cmd(Conn *c)
 
     case OP_WATCH:
         name = c->cmd + CMD_WATCH_LEN;
-        if (!name_is_ok(name, 200)) {
+        if (!name_is_ok(name, MAX_TUBE_NAME_LEN - 1)) {
             reply_msg(c, MSG_BAD_FORMAT);
             return;
         }
@@ -1727,7 +1727,7 @@ dispatch_cmd(Conn *c)
 
     case OP_IGNORE:
         name = c->cmd + CMD_IGNORE_LEN;
-        if (!name_is_ok(name, 200)) {
+        if (!name_is_ok(name, MAX_TUBE_NAME_LEN - 1)) {
             reply_msg(c, MSG_BAD_FORMAT);
             return;
         }
@@ -1765,7 +1765,7 @@ dispatch_cmd(Conn *c)
         op_ct[type]++;
 
         *delay_buf = '\0';
-        if (!name_is_ok(name, 200)) {
+        if (!name_is_ok(name, MAX_TUBE_NAME_LEN - 1)) {
             reply_msg(c, MSG_BAD_FORMAT);
             return;
         }

--- a/testserv.c
+++ b/testserv.c
@@ -1312,6 +1312,34 @@ cttest_list_tube()
     ckresp(fd0, "NOT_IGNORED\r\n");
 }
 
+#define STRING_LEN_200  \
+    "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789" \
+    "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+
+void
+cttest_use_tube_long()
+{
+    int port = SERVER();
+    int fd0 = mustdiallocal(port);
+    // 200 chars is okay
+    mustsend(fd0, "use " STRING_LEN_200 "\r\n");
+    ckresp(fd0, "USING " STRING_LEN_200 "\r\n");
+    // 201 chars is too much
+    mustsend(fd0, "use " STRING_LEN_200 "Z\r\n");
+    ckresp(fd0, "BAD_FORMAT\r\n");
+}
+
+void
+cttest_longest_command()
+{
+    int port = SERVER();
+    int fd0 = mustdiallocal(port);
+    mustsend(fd0, "use " STRING_LEN_200 "\r\n");
+    ckresp(fd0, "USING " STRING_LEN_200 "\r\n");
+    mustsend(fd0, "pause-tube " STRING_LEN_200 " 4294967295\r\n");
+    ckresp(fd0, "PAUSED\r\n");
+}
+
 void
 cttest_binlog_empty_exit()
 {

--- a/tube.c
+++ b/tube.c
@@ -8,15 +8,15 @@ struct Ms tubes;
 Tube *
 make_tube(const char *name)
 {
-    Tube *t;
+    Tube *t = new(Tube);
+    if (!t)
+        return NULL;
 
-    t = new(Tube);
-    if (!t) return NULL;
-
-    t->name[MAX_TUBE_NAME_LEN - 1] = '\0';
-    strncpy(t->name, name, MAX_TUBE_NAME_LEN - 1);
-    if (t->name[MAX_TUBE_NAME_LEN - 1] != '\0')
+    strncpy(t->name, name, MAX_TUBE_NAME_LEN);
+    if (t->name[MAX_TUBE_NAME_LEN - 1] != '\0') {
+        t->name[MAX_TUBE_NAME_LEN - 1] = '\0';
         twarnx("truncating tube name");
+    }
 
     t->ready.less = job_pri_less;
     t->delay.less = job_delay_less;


### PR DESCRIPTION
Tube truncation is checked correctly in this patch.
This should not ever happen because code calling it checks
if the tube name is shorter than 201 chars.

Also some tests and fixes for the magic number 200.

Fixes #224