### PR TITLE
improve clarity for job_list_* operations

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -34,16 +34,17 @@ on_ignore(Ms *a, Tube *t, size_t i)
 Conn *
 make_conn(int fd, char start_state, Tube *use, Tube *watch)
 {
-    Job *j;
-    Conn *c;
-
-    c = new(Conn);
-    if (!c) return twarn("OOM"), NULL;
+    Conn *c = new(Conn);
+    if (!c) {
+        twarn("OOM");
+        return NULL;
+    }
 
     ms_init(&c->watch, (ms_event_fn) on_watch, (ms_event_fn) on_ignore);
     if (!ms_append(&c->watch, watch)) {
         free(c);
-        return twarn("OOM"), NULL;
+        twarn("OOM");
+        return NULL;
     }
 
     TUBE_ASSIGN(c->use, use);
@@ -54,8 +55,9 @@ make_conn(int fd, char start_state, Tube *use, Tube *watch)
     c->pending_timeout = -1;
     c->tickpos = 0; // Does not mean anything if in_conns is set to 0.
     c->in_conns = 0;
-    j = &c->reserved_jobs;
-    j->prev = j->next = j;
+
+    // The list is empty.
+    job_list_reset(&c->reserved_jobs);
 
     /* stats */
     cur_conn_ct++;
@@ -107,7 +109,7 @@ count_cur_workers()
 static int
 has_reserved_job(Conn *c)
 {
-    return job_list_any_p(&c->reserved_jobs);
+    return !job_list_is_empty(&c->reserved_jobs);
 }
 
 
@@ -154,25 +156,43 @@ connsched(Conn *c)
     }
 }
 
+// conn_set_soonestjob updates c->soonest_job with j
+// if j should be handled sooner than c->soonest_job.
+static void
+conn_set_soonestjob(Conn *c, Job *j) {
+    if (!c->soonest_job || j->r.deadline_at < c->soonest_job->r.deadline_at) {
+        c->soonest_job = j;
+    }
+}
 
 // Return the reserved job with the earliest deadline,
-// or NULL if there's no reserved job
+// or NULL if there's no reserved job.
 Job *
 connsoonestjob(Conn *c)
 {
-    Job *j = NULL;
-    Job *soonest = c->soonest_job;
+    // use cached value and bail out.
+    if (c->soonest_job != NULL)
+        return c->soonest_job;
 
-    if (soonest == NULL) {
-        for (j = c->reserved_jobs.next; j != &c->reserved_jobs; j = j->next) {
-            if (j->r.deadline_at <= (soonest ? soonest : j)->r.deadline_at)
-                soonest = j;
-        }
+    Job *j = NULL;
+    for (j = c->reserved_jobs.next; j != &c->reserved_jobs; j = j->next) {
+        conn_set_soonestjob(c, j);
     }
-    c->soonest_job = soonest;
-    return soonest;
+    return c->soonest_job;
 }
 
+void
+conn_reserve_job(Conn *c, Job *j) {
+    j->tube->stat.reserved_ct++;
+    j->r.reserve_ct++;
+
+    j->r.deadline_at = nanoseconds() + j->r.ttr;
+    j->r.state = Reserved;
+    job_list_insert(&c->reserved_jobs, j);
+    j->reserver = c;
+    c->pending_timeout = -1;
+    conn_set_soonestjob(c, j);
+}
 
 // Return true if c has a reserved job with less than one second until its
 // deadline.

--- a/dat.h
+++ b/dat.h
@@ -309,9 +309,10 @@ Job *job_copy(Job *j);
 
 const char * job_state(Job *j);
 
-int job_list_any_p(Job *head);
-Job *job_remove(Job *j);
-void job_insert(Job *head, Job *j);
+void job_list_reset(Job *head);
+int job_list_is_empty(Job *head);
+Job *job_list_remove(Job *j);
+void job_list_insert(Job *head, Job *j);
 
 /* for unit tests */
 size_t get_all_jobs_used(void);
@@ -343,7 +344,7 @@ extern size_t job_data_size_limit;
 void prot_init(void);
 int64 prottick(Server *s);
 
-Conn *remove_waiting_conn(Conn *c);
+void remove_waiting_conn(Conn *c);
 
 void enqueue_reserved_jobs(Conn *c);
 
@@ -412,6 +413,7 @@ void connsetworker(Conn *c);
 Job *connsoonestjob(Conn *c);
 int  conndeadlinesoon(Conn *c);
 int conn_ready(Conn *c);
+void conn_reserve_job(Conn *c, Job *j);
 #define conn_waiting(c) ((c)->type & CONN_TYPE_WAITING)
 
 

--- a/file.c
+++ b/file.c
@@ -212,11 +212,11 @@ readrec(File *f, Job *l, int *err)
             t = tube_find_or_make(tubename);
             j = make_job_with_id(jr.pri, jr.delay, jr.ttr, jr.body_size,
                                  t, jr.id);
-            j->next = j->prev = j;
+            job_list_reset(j);
             j->r.created_at = jr.created_at;
         }
         j->r = jr;
-        job_insert(l, j);
+        job_list_insert(l, j);
 
         // full record; read the job body
         if (namelen) {
@@ -243,7 +243,7 @@ readrec(File *f, Job *l, int *err)
         return 1;
     case Invalid:
         if (j) {
-            job_remove(j);
+            job_list_remove(j);
             filermjob(j->file, j);
             job_free(j);
         }
@@ -253,7 +253,7 @@ readrec(File *f, Job *l, int *err)
 Error:
     *err = 1;
     if (j) {
-        job_remove(j);
+        job_list_remove(j);
         filermjob(j->file, j);
         job_free(j);
     }
@@ -337,7 +337,7 @@ readrec5(File *f, Job *l, int *err)
             t = tube_find_or_make(tubename);
             j = make_job_with_id(jr.pri, jr.delay, jr.ttr, jr.body_size,
                                  t, jr.id);
-            j->next = j->prev = j;
+            job_list_reset(j);
         }
         j->r.id = jr.id;
         j->r.pri = jr.pri;
@@ -352,7 +352,7 @@ readrec5(File *f, Job *l, int *err)
         j->r.bury_ct = jr.bury_ct;
         j->r.kick_ct = jr.kick_ct;
         j->r.state = jr.state;
-        job_insert(l, j);
+        job_list_insert(l, j);
 
         // full record; read the job body
         if (namelen) {
@@ -379,7 +379,7 @@ readrec5(File *f, Job *l, int *err)
         return 1;
     case Invalid:
         if (j) {
-            job_remove(j);
+            job_list_remove(j);
             filermjob(j->file, j);
             job_free(j);
         }
@@ -389,7 +389,7 @@ readrec5(File *f, Job *l, int *err)
 Error:
     *err = 1;
     if (j) {
-        job_remove(j);
+        job_list_remove(j);
         filermjob(j->file, j);
         job_free(j);
     }

--- a/job.c
+++ b/job.c
@@ -104,7 +104,7 @@ allocate_job(int body_size)
     j->r.created_at = nanoseconds();
     j->r.body_size = body_size;
     j->body = (char *)j + sizeof(Job);
-    j->next = j->prev = j;      // not in a linked list
+    job_list_reset(j);
     return j;
 }
 
@@ -115,7 +115,10 @@ make_job_with_id(uint32 pri, int64 delay, int64 ttr,
     Job *j;
 
     j = allocate_job(body_size);
-    if (!j) return twarnx("OOM"), (Job *) 0;
+    if (!j) {
+        twarnx("OOM");
+        return (Job *) 0;
+    }
 
     if (id) {
         j->r.id = id;
@@ -190,15 +193,16 @@ job_delay_less(void *ja, void *jb)
 Job *
 job_copy(Job *j)
 {
-    Job *n;
-
     if (!j) return NULL;
 
-    n = malloc(sizeof(Job) + j->r.body_size);
-    if (!n) return twarnx("OOM"), (Job *) 0;
+    Job *n = malloc(sizeof(Job) + j->r.body_size);
+    if (!n) {
+        twarnx("OOM");
+        return (Job *) 0;
+    }
 
     memcpy(n, j, sizeof(Job) + j->r.body_size);
-    n->next = n->prev = n; /* not in a linked list */
+    job_list_reset(n);
 
     n->file = NULL; /* copies do not have refcnt on the wal */
 
@@ -221,30 +225,39 @@ job_state(Job *j)
     return "invalid";
 }
 
-int
-job_list_any_p(Job *head)
+// job_list_reset detaches head from the list,
+// marking the list starting in head pointing to itself.
+void
+job_list_reset(Job *head)
 {
-    return head->next != head || head->prev != head;
+    head->prev = head;
+    head->next = head;
+}
+
+int
+job_list_is_empty(Job *head)
+{
+    return head->next == head && head->prev == head;
 }
 
 Job *
-job_remove(Job *j)
+job_list_remove(Job *j)
 {
     if (!j) return NULL;
-    if (!job_list_any_p(j)) return NULL; /* not in a doubly-linked list */
+    if (job_list_is_empty(j)) return NULL; /* not in a doubly-linked list */
 
     j->next->prev = j->prev;
     j->prev->next = j->next;
 
-    j->prev = j->next = j;
+    job_list_reset(j);
 
     return j;
 }
 
 void
-job_insert(Job *head, Job *j)
+job_list_insert(Job *head, Job *j)
 {
-    if (job_list_any_p(j)) return; /* already in a linked list */
+    if (!job_list_is_empty(j)) return; /* already in a linked list */
 
     j->prev = head->prev;
     j->next = head;

--- a/net.c
+++ b/net.c
@@ -218,7 +218,8 @@ make_server_socket(char *host, char *port)
      * and return. */
     r = sd_listen_fds(1);
     if (r < 0) {
-        return twarn("sd_listen_fds"), -1;
+        twarn("sd_listen_fds");
+        return -1;
     }
     if (r > 0) {
         if (r > 1) {


### PR DESCRIPTION
Bunch of functions renamed here and there.
remote_waiting_conn() does not return anything anymore,
instead it is noop for not waiting connection.

reserve_job() body mostly was moved to conn_reserve_job().
the rest was left in place of the call to it.