### PR TITLE
write blocks to allocate files in rawfalloc on every OS

### DIFF
--- a/darwin.c
+++ b/darwin.c
@@ -14,26 +14,6 @@ enum
 };
 
 static int  kq;
-static char buf0[512]; /* buffer of zeros */
-
-
-/* Allocate disk space.
- * Expects fd's offset to be 0; may also reset fd's offset to 0.
- * Returns 0 on success, and a positive errno otherwise. */
-int
-rawfalloc(int fd, int len)
-{
-    int i, w;
-
-    for (i = 0; i < len; i += w) {
-        w = write(fd, buf0, sizeof buf0);
-        if (w == -1) return errno;
-    }
-
-    lseek(fd, 0, 0); /* do not care if this fails */
-
-    return 0;
-}
 
 
 int

--- a/linux.c
+++ b/linux.c
@@ -16,24 +16,6 @@
 static int epfd;
 
 
-/* Allocate disk space.
- * Expects fd's offset to be 0; may also reset fd's offset to 0.
- * Returns 0 on success, and a positive errno otherwise. */
-int
-rawfalloc(int fd, int len)
-{
-    // XSI-conformant systems might not extend the file and return an error.
-    // ftruncate() might extend the file with a sequence of null bytes or a hole.
-    // Latter means that disk blocks are not allocated before the write happens.
-    // To ensure that write won't fail because disk space is exhausted,
-    // we might use posix_fallocate() that ensures disk allocation, but it
-    // has limited support for NFS. Optionally can revert to regular write as on osx.
-    if (!ftruncate(fd, len))
-        return 0;
-    return errno;
-}
-
-
 int
 sockinit(void)
 {

--- a/sunos.c
+++ b/sunos.c
@@ -9,26 +9,6 @@
 #include "dat.h"
 
 static int portfd;
-static char buf0[512]; /* buffer of zeros */
-
-/* Allocate disk space.
- * Expects fd's offset to be 0; may also reset fd's offset to 0.
- * Returns 0 on success, and a positive errno otherwise. */
-int
-rawfalloc(int fd, int len)
-{
-    int i, w;
-
-    for (i = 0; i < len; i += w) {
-        w = write(fd, buf0, sizeof buf0);
-        if (w == -1) return errno;
-    }
-
-    lseek(fd, 0, 0); /* do not care if this fails */
-
-    return 0;
-}
-
 
 int
 sockinit(void)

--- a/testserv.c
+++ b/testserv.c
@@ -1403,7 +1403,7 @@ cttest_binlog_size_limit()
     int i = 0;
     int gotsize;
 
-    size = 1024;
+    size = 4096;
     srv.wal.dir = ctdir();
     srv.wal.use = 1;
     srv.wal.filesize = size;

--- a/util.c
+++ b/util.c
@@ -108,7 +108,7 @@ usage(int code)
             " -u USER  become user and group\n"
             " -z BYTES set the maximum job size in bytes (default is %d, max allowed is %d)\n"
             " -s BYTES set the size of each write-ahead log file (default is %d)\n"
-            "            (will be rounded up to a multiple of 512 bytes)\n"
+            "            (will be rounded up to a multiple of 4096 bytes)\n"
             " -c       compact the binlog (default)\n"
             " -n       do not compact the binlog\n"
             " -v       show version information\n"


### PR DESCRIPTION
Instead of having Linux implementation that uses ftruncate,
allocate files by writing 4096 bytes blocks.

Fixes #537