### PR TITLE
add the OS version and platform to the stats command

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -78,13 +78,13 @@ extern FAlloc *falloc;
 
 // stats structure holds counters for operations, both globally and per tube.
 struct stats {
-    uint urgent_ct;
-    uint waiting_ct;
-    uint buried_ct;
-    uint reserved_ct;
-    uint pause_ct;
-    uint64   total_delete_ct;
-    uint64   total_jobs_ct;
+    uint64 urgent_ct;
+    uint64 waiting_ct;
+    uint64 buried_ct;
+    uint64 reserved_ct;
+    uint64 pause_ct;
+    uint64 total_delete_ct;
+    uint64 total_jobs_ct;
 };
 
 

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -657,7 +657,11 @@ they are not stored on disk with the -b flag.
  - "id" is a random id string for this server process, generated every time
    beanstalkd process starts.
 
- - "hostname" the hostname of the machine as determined by uname.
+ - "hostname" is the hostname of the machine as determined by uname.
+
+ - "os" is the OS version as determined by uname
+
+ - "platform" is the machine architecture as determined by uname
 
 The list-tubes command returns a list of all existing tubes. Its form is:
 


### PR DESCRIPTION
The motivation is to have more detailed stats command so that users can report it when they have some problems.

Make counters as uint64 where possible, and rearrange the code.