### PR TITLE
remove the -c and -n flags that control log compaction

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -440,7 +440,6 @@ struct Wal {
     int    wantsync;
     int64  syncrate;
     int64  lastsync;
-    int    nocomp; // disable binlog compaction?
 };
 int  waldirlock(Wal*);
 void walinit(Wal*, Job *list);

--- a/doc/beanstalkd.1
+++ b/doc/beanstalkd.1
@@ -22,13 +22,6 @@ When started, \fBbeanstalkd\fR opens a socket (or uses a file descriptor provide
 Use a binlog to keep jobs on persistent storage in directory \fIpath\fR\. Upon startup, \fBbeanstalkd\fR will recover any binlog that is present in \fIpath\fR, then, during normal operation, append new jobs and changes in state to the binlog\.
 .
 .TP
-\fB\-c\fR
-Perform online, incremental compaction of binlog files\. Negates \fB\-n\fR\. This is the default behavior\.
-.
-.IP
-(Do not use this option, except to negate \fB\-n\fR\. Both \fB\-c\fR and \fB\-n\fR will likely be removed in a future \fBbeanstalkd\fR release\.)
-.
-.TP
 \fB\-f\fR \fIms\fR
 Call fsync(2) at most once every \fIms\fR milliseconds\. Larger values for \fIms\fR reduce disk activity and improve speed at the cost of safety\. A power failure could result in the loss of up to \fIms\fR milliseconds of history\.
 .
@@ -63,13 +56,6 @@ When \fIaddr\fR starts with "unix:", the unprefixed value of it will be used as 
 (Option \fB\-l\fR has no effect if sd\-daemon(5) socket activation is being used\. See also \fIENVIRONMENT\fR\.)
 .
 .TP
-\fB\-n\fR
-Turn off binlog compaction, negating \fB\-c\fR\.
-.
-.IP
-(Do not use this option\. Both \fB\-c\fR and \fB\-n\fR will likely be removed in a future \fBbeanstalkd\fR release\.)
-.
-.TP
 \fB\-p\fR \fIport\fR
 Listen on TCP port \fIport\fR (default is 11300)\.
 .
@@ -99,6 +85,14 @@ Print the version string and exit\.
 \fB\-z\fR \fIbytes\fR
 The maximum size in bytes of a job\.
 .
+.TP
+\fB\-c\fR
+This flag has no effect\. It is kept for historical compatibility only\.
+.
+.TP
+\fB\-n\fR
+This flag has no effect\. It is kept for historical compatibility only\.
+.
 .SH "ENVIRONMENT"
 .
 .TP
@@ -115,4 +109,4 @@ Files \fBREADME\fR and \fBdoc/protocol\.txt\fR in the \fBbeanstalkd\fR distribut
 \fIhttps://beanstalkd\.github\.io/\fR
 .
 .SH "AUTHOR"
-\fBBeanstalkd\fR is written and maintained by Keith Rarick with the help of many others\.
+\fBBeanstalkd\fR is written by Keith Rarick and maintained by the community at \fIhttps://github\.com/beanstalkd/beanstalkd/issues\fR

--- a/doc/beanstalkd.1.html
+++ b/doc/beanstalkd.1.html
@@ -99,11 +99,6 @@ and format of the <code>beanstalkd</code> protocol.</p>
 Upon startup, <code>beanstalkd</code> will recover any binlog that is present
 in <var>path</var>, then, during normal operation, append new jobs and
 changes in state to the binlog.</p></dd>
-<dt class="flush"><code>-c</code></dt><dd><p>Perform online, incremental compaction of binlog files. Negates
-<code>-n</code>. This is the default behavior.</p>
-
-<p>(Do not use this option, except to negate <code>-n</code>. Both <code>-c</code> and <code>-n</code>
-will likely be removed in a future <code>beanstalkd</code> release.)</p></dd>
 <dt class="flush"><code>-f</code> <var>ms</var></dt><dd><p>Call <span class="man-ref">fsync<span class="s">(2)</span></span> at most once every <var>ms</var> milliseconds. Larger values
 for <var>ms</var> reduce disk activity and improve speed at the cost of
 safety. A power failure could result in the loss of up to <var>ms</var>
@@ -127,10 +122,6 @@ a TCP socket. In this case the value of <code>-p</code> will be ignored.</p>
 
 <p>(Option <code>-l</code> has no effect if <span class="man-ref">sd-daemon<span class="s">(5)</span></span> socket activation is
 being used. See also <a href="#ENVIRONMENT" title="ENVIRONMENT" data-bare-link="true">ENVIRONMENT</a>.)</p></dd>
-<dt class="flush"><code>-n</code></dt><dd><p>Turn off binlog compaction, negating <code>-c</code>.</p>
-
-<p>(Do not use this option. Both <code>-c</code> and <code>-n</code> will likely be removed
-in a future <code>beanstalkd</code> release.)</p></dd>
 <dt class="flush"><code>-p</code> <var>port</var></dt><dd><p>Listen on TCP port <var>port</var> (default is 11300).</p>
 
 <p>(Option <code>-p</code> has no effect if <span class="man-ref">sd-daemon<span class="s">(5)</span></span> socket activation is
@@ -143,6 +134,8 @@ being used. See also <a href="#ENVIRONMENT" title="ENVIRONMENT" data-bare-link="
 verbose output. The output format is subject to change.</p></dd>
 <dt class="flush"><code>-v</code></dt><dd><p>Print the version string and exit.</p></dd>
 <dt><code>-z</code> <var>bytes</var></dt><dd><p>The maximum size in bytes of a job.</p></dd>
+<dt class="flush"><code>-c</code></dt><dd><p>This flag has no effect. It is kept for historical compatibility only.</p></dd>
+<dt class="flush"><code>-n</code></dt><dd><p>This flag has no effect. It is kept for historical compatibility only.</p></dd>
 </dl>
 
 
@@ -165,8 +158,8 @@ distribution.</p>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p><code>Beanstalkd</code> is written and maintained by Keith Rarick with the help
-of many others.</p>
+<p><code>Beanstalkd</code> is written by Keith Rarick and maintained by the community at
+<a href="https://github.com/beanstalkd/beanstalkd/issues" data-bare-link="true">https://github.com/beanstalkd/beanstalkd/issues</a></p>
 
 
   <ol class='man-decor man-foot man foot'>

--- a/doc/beanstalkd.ronn
+++ b/doc/beanstalkd.ronn
@@ -28,13 +28,6 @@ and format of the `beanstalkd` protocol.
   in <path>, then, during normal operation, append new jobs and
   changes in state to the binlog.
 
-* `-c`:
-  Perform online, incremental compaction of binlog files. Negates
-  `-n`. This is the default behavior.
-
-  (Do not use this option, except to negate `-n`. Both `-c` and `-n`
-  will likely be removed in a future `beanstalkd` release.)
-
 * `-f` <ms>:
   Call fsync(2) at most once every <ms> milliseconds. Larger values
   for <ms> reduce disk activity and improve speed at the cost of
@@ -66,12 +59,6 @@ and format of the `beanstalkd` protocol.
   (Option `-l` has no effect if sd-daemon(5) socket activation is
   being used. See also [ENVIRONMENT][].)
 
-* `-n`:
-  Turn off binlog compaction, negating `-c`.
-
-  (Do not use this option. Both `-c` and `-n` will likely be removed
-  in a future `beanstalkd` release.)
-
 * `-p` <port>:
   Listen on TCP port <port> (default is 11300).
 
@@ -96,6 +83,12 @@ and format of the `beanstalkd` protocol.
 * `-z` <bytes>:
   The maximum size in bytes of a job.
 
+* `-c`:
+  This flag has no effect. It is kept for historical compatibility only.
+
+* `-n`:
+  This flag has no effect. It is kept for historical compatibility only.
+
 ## ENVIRONMENT
 
 * `LISTEN_PID`, `LISTEN_FDS`:
@@ -113,5 +106,5 @@ distribution.
 
 ## AUTHOR
 
-`Beanstalkd` is written and maintained by Keith Rarick with the help
-of many others.
+`Beanstalkd` is written by Keith Rarick and maintained by the community at
+<https://github.com/beanstalkd/beanstalkd/issues>

--- a/testutil.c
+++ b/testutil.c
@@ -29,7 +29,6 @@ cttest_opt_none()
     assert(srv.addr == NULL);
     assert(job_data_size_limit == JOB_DATA_SIZE_LIMIT_DEFAULT);
     assert(srv.wal.filesize == Filesizedef);
-    assert(srv.wal.nocomp == 0);
     assert(srv.wal.wantsync == 0);
     assert(srv.user == NULL);
     assert(srv.wal.dir == NULL);
@@ -130,31 +129,6 @@ cttest_opts()
 }
 
 void
-cttest_optc()
-{
-    char *args[] = {
-        "-n",
-        "-c",
-        NULL,
-    };
-
-    optparse(&srv, args);
-    assert(srv.wal.nocomp == 0);
-}
-
-void
-cttest_optn()
-{
-    char *args[] = {
-        "-n",
-        NULL,
-    };
-
-    optparse(&srv, args);
-    assert(srv.wal.nocomp == 1);
-}
-
-void
 cttest_optf()
 {
     char *args[] = {
@@ -243,15 +217,15 @@ cttest_optVVV()
 }
 
 void
-cttest_optVnVu()
+cttest_optVFVu()
 {
     char *args[] = {
-        "-VnVukr",
+        "-VFVukr",
         NULL,
     };
 
     optparse(&srv, args);
     assert(verbose == 2);
-    assert(srv.wal.nocomp == 1);
+    assert(srv.wal.wantsync == 0);
     assert(strcmp(srv.user, "kr") == 0);
 }

--- a/util.c
+++ b/util.c
@@ -109,8 +109,6 @@ usage(int code)
             " -z BYTES set the maximum job size in bytes (default is %d, max allowed is %d)\n"
             " -s BYTES set the size of each write-ahead log file (default is %d)\n"
             "            (will be rounded up to a multiple of 4096 bytes)\n"
-            " -c       compact the binlog (default)\n"
-            " -n       do not compact the binlog\n"
             " -v       show version information\n"
             " -V       increase verbosity\n"
             " -h       show this help\n",
@@ -176,10 +174,10 @@ optparse(Server *s, char **argv)
                     s->wal.filesize = parse_size_t(EARGF(flagusage("-s")));
                     break;
                 case 'c':
-                    s->wal.nocomp = 0;
+                    warnx("-c flag was removed. binlog is always compacted.");
                     break;
                 case 'n':
-                    s->wal.nocomp = 1;
+                    warnx("-n flag was removed. binlog is always compacted.");
                     break;
                 case 'f':
                     ms = (int64)parse_size_t(EARGF(flagusage("-f")));

--- a/walg.c
+++ b/walg.c
@@ -201,9 +201,7 @@ void
 walmaint(Wal *w)
 {
     if (w->use) {
-        if (!w->nocomp) {
-            walcompact(w);
-        }
+        walcompact(w);
         walsync(w);
     }
 }


### PR DESCRIPTION
Log compaction should not be switched off.

Fixes #552