### PR TITLE
fix response for the command that is too long

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -42,7 +42,8 @@ the server will reply with one of the following error messages:
    http://groups.google.com/group/beanstalk-talk.
 
  - "BAD_FORMAT\r\n" The client sent a command line that was not well-formed.
-   This can happen if the line does not end with \r\n, if non-numeric
+   This can happen if the line's length exceeds 224 bytes including \r\n,
+   if the name of a tube exceeds 200 bytes, if non-numeric
    characters occur where an integer is expected, if the wrong number of
    arguments are present, or if the command line is mal-formed in any other
    way.

--- a/testserv.c
+++ b/testserv.c
@@ -380,10 +380,15 @@ cttest_too_long_commandline()
     int port = SERVER();
     int fd = mustdiallocal(port);
     int i;
-    for (i = 0; i < 5; i++)
-        mustsend(fd, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    for (i = 0; i < 10; i++)
+        mustsend(fd, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"); // 50 bytes
     mustsend(fd, "\r\n");
     ckresp(fd, "BAD_FORMAT\r\n");
+    // Issue another command and check that reponse is not "UNKNOWN_COMMAND"
+    // as described in issue #337
+    mustsend(fd, "put 0 0 1 1\r\n");
+    mustsend(fd, "A\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
 }
 
 void


### PR DESCRIPTION
Before the patch, if a client sent too long command, server would
respond by BAD_FORMAT, followed by UNKNOWN_COMMAND. This resulted
in desync between client and server.

This patch adds another state STATE_WANT_ENDLINE,
whose purpose is to drop command line until the EOL is found.
Client can send as big command as he want and server will be able
to skip it and return only one error message: BAD_FORMAT.

Some STATE_* constants were renamed to improve readability.

Fixes #337