### PR TITLE
add the "reserve-job" command

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -251,6 +251,23 @@ in the form of a text line followed by the job body:
    previous line. This is a verbatim copy of the bytes that were originally
    sent to the server in the put command for this job.
 
+A job can be reserved by its id. Once a job is reserved for the client,
+the client has limited time to run (TTR) the job before the job times out.
+When the job times out, the server will put the job back into the ready queue.
+The command looks like this:
+
+    reserve-job <id>\r\n
+
+- <id> is the job id to reserve
+
+This should immediately return one of these responses:
+
+- "NOT_FOUND\r\n" if the job does not exist or reserved by a client or
+  is not either ready, buried or delayed.
+
+- "RESERVED <id> <bytes>\r\n<data>\r\n". See the description for
+  the reserve command.
+
 The delete command removes a job from the server entirely. It is normally used
 by the client when the job has successfully run to completion. A client can
 delete jobs that it has reserved, ready jobs, delayed jobs, and jobs that are

--- a/job.c
+++ b/job.c
@@ -81,10 +81,11 @@ rehash(int is_upscaling)
 Job *
 job_find(uint64 job_id)
 {
-    Job *jh = NULL;
     int index = _get_job_hash_index(job_id);
+    Job *jh = all_jobs[index];
 
-    for (jh = all_jobs[index]; jh && jh->r.id != job_id; jh = jh->ht_next);
+    while (jh && jh->r.id != job_id)
+        jh = jh->ht_next;
 
     return jh;
 }

--- a/testserv.c
+++ b/testserv.c
@@ -1121,36 +1121,209 @@ void
 cttest_reserve_ttr_deadline_soon()
 {
     int port = SERVER();
-    int prod = mustdiallocal(port);
+    int fd = mustdiallocal(port);
 
-    mustsend(prod, "put 0 0 1 1\r\n");
-    mustsend(prod, "a\r\n");
-    ckresp(prod, "INSERTED 1\r\n");
+    mustsend(fd, "put 0 0 1 1\r\n");
+    mustsend(fd, "a\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
 
-    mustsend(prod, "reserve-with-timeout 1\r\n");
-    ckresp(prod, "RESERVED 1 1\r\n");
-    ckresp(prod, "a\r\n");
+    mustsend(fd, "reserve-with-timeout 1\r\n");
+    ckresp(fd, "RESERVED 1 1\r\n");
+    ckresp(fd, "a\r\n");
 
-    // After 0.3s the job should be still reserved.
-    usleep(300000);
-    mustsend(prod, "stats-job 1\r\n");
-    ckrespsub(prod, "OK ");
-    ckrespsub(prod, "\nstate: reserved\n");
+    // After 0.2s the job should be still reserved.
+    usleep(200000);
+    mustsend(fd, "stats-job 1\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\nstate: reserved\n");
 
-    mustsend(prod, "reserve-with-timeout 1\r\n");
-    ckresp(prod, "DEADLINE_SOON\r\n");
+    mustsend(fd, "reserve-with-timeout 1\r\n");
+    ckresp(fd, "DEADLINE_SOON\r\n");
 
     // Job should be reserved; last "reserve" took less than 1s.
-    mustsend(prod, "stats-job 1\r\n");
-    ckrespsub(prod, "OK ");
-    ckrespsub(prod, "\nstate: reserved\n");
+    mustsend(fd, "stats-job 1\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\nstate: reserved\n");
 
     // We don't want to process the job, so release it and check that it's ready.
-    mustsend(prod, "release 1 0 0\r\n");
-    ckresp(prod, "RELEASED\r\n");
-    mustsend(prod, "stats-job 1\r\n");
-    ckrespsub(prod, "OK ");
-    ckrespsub(prod, "\nstate: ready\n");
+    mustsend(fd, "release 1 0 0\r\n");
+    ckresp(fd, "RELEASED\r\n");
+    mustsend(fd, "stats-job 1\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\nstate: ready\n");
+}
+
+void
+cttest_reserve_job_ttr_deadline_soon()
+{
+    int port = SERVER();
+    int fd = mustdiallocal(port);
+
+    mustsend(fd, "put 0 5 1 1\r\n");
+    mustsend(fd, "a\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
+
+    mustsend(fd, "stats-job 1\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\nstate: delayed\n");
+
+    mustsend(fd, "reserve-job 1\r\n");
+    ckresp(fd, "RESERVED 1 1\r\n");
+    ckresp(fd, "a\r\n");
+
+    // After 0.1s the job should be still reserved.
+    usleep(100000);
+    mustsend(fd, "stats-job 1\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\nstate: reserved\n");
+
+    // Reservation made with reserve-job should behave the same way as other
+    // reserve commands, e.g. produce "deadline soon" message, and get released
+    // when ttr ends.
+    mustsend(fd, "reserve-with-timeout 1\r\n");
+    ckresp(fd, "DEADLINE_SOON\r\n");
+
+    // Job should be reserved; last "reserve" took less than 1s.
+    mustsend(fd, "stats-job 1\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\nstate: reserved\n");
+
+    // We are not able to process the job in time. Check that it gets released.
+    // The job was in delayed state. It becomes ready when it gets auto-released.
+    usleep(1000000); // 1.0s
+    // put a dummy job
+    mustsend(fd, "put 0 0 1 1\r\n");
+    mustsend(fd, "B\r\n");
+    ckresp(fd, "INSERTED 2\r\n");
+    // check that ID=1 gets released
+    mustsend(fd, "stats-job 1\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\nstate: ready\n");
+}
+
+void
+cttest_reserve_job_already_reserved()
+{
+    int port = SERVER();
+    int fd = mustdiallocal(port);
+
+    mustsend(fd, "put 0 0 1 1\r\n");
+    mustsend(fd, "A\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
+
+    mustsend(fd, "reserve-job 1\r\n");
+    ckresp(fd, "RESERVED 1 1\r\n");
+    ckresp(fd, "A\r\n");
+
+    // Job should not be reserved twice.
+    mustsend(fd, "reserve-job 1\r\n");
+    ckresp(fd, "NOT_FOUND\r\n");
+}
+
+void
+cttest_reserve_job_ready()
+{
+    int port = SERVER();
+    int fd = mustdiallocal(port);
+
+    mustsend(fd, "put 0 0 1 1\r\n");
+    mustsend(fd, "A\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
+    mustsend(fd, "put 0 0 1 1\r\n");
+    mustsend(fd, "B\r\n");
+    ckresp(fd, "INSERTED 2\r\n");
+
+    mustsend(fd, "reserve-job 2\r\n");
+    ckresp(fd, "RESERVED 2 1\r\n");
+    ckresp(fd, "B\r\n");
+
+    // Non-existing job.
+    mustsend(fd, "reserve-job 3\r\n");
+    ckresp(fd, "NOT_FOUND\r\n");
+
+    // id=1 was not reserved.
+    mustsend(fd, "release 1 1 0\r\n");
+    ckresp(fd, "NOT_FOUND\r\n");
+
+    mustsend(fd, "release 2 1 0\r\n");
+    ckresp(fd, "RELEASED\r\n");
+}
+
+void
+cttest_reserve_job_delayed()
+{
+    int port = SERVER();
+    int fd = mustdiallocal(port);
+
+    mustsend(fd, "put 0 100 1 1\r\n");
+    mustsend(fd, "A\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
+    mustsend(fd, "put 0 100 1 1\r\n");
+    mustsend(fd, "B\r\n");
+    ckresp(fd, "INSERTED 2\r\n");
+    mustsend(fd, "put 0 100 1 1\r\n");
+    mustsend(fd, "C\r\n");
+    ckresp(fd, "INSERTED 3\r\n");
+
+    mustsend(fd, "reserve-job 2\r\n");
+    ckresp(fd, "RESERVED 2 1\r\n");
+    ckresp(fd, "B\r\n");
+
+    mustsend(fd, "release 2 1 0\r\n");
+    ckresp(fd, "RELEASED\r\n");
+
+    // verify that job was released in ready state.
+    mustsend(fd, "stats-job 2\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\nstate: ready\n");
+}
+
+void
+cttest_reserve_job_buried()
+{
+    int port = SERVER();
+    int fd = mustdiallocal(port);
+
+    // put, reserve and bury
+    mustsend(fd, "put 0 0 1 1\r\n");
+    mustsend(fd, "A\r\n");
+    ckresp(fd, "INSERTED 1\r\n");
+    mustsend(fd, "reserve-job 1\r\n");
+    ckresp(fd, "RESERVED 1 1\r\n");
+    ckresp(fd, "A\r\n");
+    mustsend(fd, "bury 1 1\r\n");
+    ckresp(fd, "BURIED\r\n");
+
+    // put, reserve and bury
+    mustsend(fd, "put 0 0 1 1\r\n");
+    mustsend(fd, "B\r\n");
+    ckresp(fd, "INSERTED 2\r\n");
+    mustsend(fd, "reserve-job 2\r\n");
+    ckresp(fd, "RESERVED 2 1\r\n");
+    ckresp(fd, "B\r\n");
+    mustsend(fd, "bury 2 1\r\n");
+    ckresp(fd, "BURIED\r\n");
+
+    // reserve by ids
+    mustsend(fd, "reserve-job 2\r\n");
+    ckresp(fd, "RESERVED 2 1\r\n");
+    ckresp(fd, "B\r\n");
+    mustsend(fd, "reserve-job 1\r\n");
+    ckresp(fd, "RESERVED 1 1\r\n");
+    ckresp(fd, "A\r\n");
+
+    // release back and check if jobs are ready.
+    mustsend(fd, "release 1 1 0\r\n");
+    ckresp(fd, "RELEASED\r\n");
+    mustsend(fd, "release 2 1 0\r\n");
+    ckresp(fd, "RELEASED\r\n");
+    mustsend(fd, "stats-job 1\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\nstate: ready\n");
+    mustsend(fd, "stats-job 2\r\n");
+    ckrespsub(fd, "OK ");
+    ckrespsub(fd, "\nstate: ready\n");
+
 }
 
 void


### PR DESCRIPTION
A job can be reserved by an ID in the Ready, Buried or Delayed states.
Reservation made with this command does not differ from reservations
made by "reserve" or "reserve-with-timeout" commands. The new command
does not produce "deadline soon" when there are other jobs about to expire.

Fixes #310
Fixes #222
Fixes #240
