### PR TITLE
fix GCC9 compiler warnings

### DIFF
--- a/sd-daemon.c
+++ b/sd-daemon.c
@@ -360,7 +360,8 @@ int sd_notify(int unset_environment, const char *state) {
 
         memset(&sockaddr, 0, sizeof(sockaddr));
         sockaddr.sa.sa_family = AF_UNIX;
-        strncpy(sockaddr.un.sun_path, e, sizeof(sockaddr.un.sun_path));
+        strncpy(sockaddr.un.sun_path, e, sizeof(sockaddr.un.sun_path) - 1);
+        sockaddr.un.sun_path[sizeof(sockaddr.un.sun_path) - 1] = '\0';
 
         if (sockaddr.un.sun_path[0] == '@')
                 sockaddr.un.sun_path[0] = 0;


### PR DESCRIPTION
this program will not compile OOTB with GCC9 because of '-Wall -Werror' in the Makefile

take special care of the strncpy patch - i make no claim that it is a safe fix; but it works