### PR TITLE
sync to the disk every 50ms as default behaviour

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -62,6 +62,9 @@ typedef int(FAlloc)(int, int);
 // The width is restricted by Jobrec.body_size that is int32.
 #define JOB_DATA_SIZE_LIMIT_MAX 1073741824
 
+// The default value for the fsync (-f) parameter, milliseconds.
+#define DEFAULT_FSYNC_MS 50
+
 // Use this macro to designate unused parameters in functions.
 #define UNUSED_PARAMETER(x) (void)(x)
 
@@ -437,8 +440,8 @@ struct Wal {
     int64  alive; // bytes in use
     int64  nmig;  // migrations
     int64  nrec;  // records written ever
-    int    wantsync;
-    int64  syncrate;
+    int    wantsync; // do we sync to disk?
+    int64  syncrate; // how often we sync to disk, in nanoseconds
     int64  lastsync;
 };
 int  waldirlock(Wal*);

--- a/serv.c
+++ b/serv.c
@@ -7,6 +7,8 @@ struct Server srv = {
     .port = Portdef,
     .wal = {
         .filesize = Filesizedef,
+        .wantsync = 1,
+        .syncrate = DEFAULT_FSYNC_MS * 1000000,
     },
 };
 

--- a/testserv.c
+++ b/testserv.c
@@ -2054,13 +2054,13 @@ ctbench_put_delete_wal_1024_fsync_000ms(int n)
 void
 ctbench_put_delete_wal_1024_fsync_050ms(int n)
 {
-    bench_put_delete_size(n, 1024, 512000, 1, 100);
+    bench_put_delete_size(n, 1024, 512000, 1, 50);
 }
 
 void
 ctbench_put_delete_wal_1024_fsync_200ms(int n)
 {
-    bench_put_delete_size(n, 1024, 512000, 1, 500);
+    bench_put_delete_size(n, 1024, 512000, 1, 200);
 }
 
 void
@@ -2078,13 +2078,13 @@ ctbench_put_delete_wal_8192_fsync_000ms(int n)
 void
 ctbench_put_delete_wal_8192_fsync_050ms(int n)
 {
-    bench_put_delete_size(n, 8192, 512000, 1, 100);
+    bench_put_delete_size(n, 8192, 512000, 1, 50);
 }
 
 void
 ctbench_put_delete_wal_8192_fsync_200ms(int n)
 {
-    bench_put_delete_size(n, 8192, 512000, 1, 500);
+    bench_put_delete_size(n, 8192, 512000, 1, 200);
 }
 
 void

--- a/testutil.c
+++ b/testutil.c
@@ -29,7 +29,8 @@ cttest_opt_none()
     assert(srv.addr == NULL);
     assert(job_data_size_limit == JOB_DATA_SIZE_LIMIT_DEFAULT);
     assert(srv.wal.filesize == Filesizedef);
-    assert(srv.wal.wantsync == 0);
+    assert(srv.wal.wantsync == 1);
+    assert(srv.wal.syncrate == DEFAULT_FSYNC_MS*1000000);
     assert(srv.user == NULL);
     assert(srv.wal.dir == NULL);
     assert(srv.wal.use == 0);

--- a/util.c
+++ b/util.c
@@ -105,19 +105,21 @@ usage(int code)
             "\n"
             "Options:\n"
             " -b DIR   write-ahead log directory\n"
-            " -f MS    fsync at most once every MS milliseconds"
-                       " (use -f0 for \"always fsync\")\n"
-            " -F       never fsync (default)\n"
+            " -f MS    fsync at most once every MS milliseconds (default is %dms);\n"
+            "          use -f0 for \"always fsync\"\n"
+            " -F       never fsync\n"
             " -l ADDR  listen on address (default is 0.0.0.0)\n"
             " -p PORT  listen on port (default is " Portdef ")\n"
             " -u USER  become user and group\n"
-            " -z BYTES set the maximum job size in bytes (default is %d, max allowed is %d)\n"
-            " -s BYTES set the size of each write-ahead log file (default is %d)\n"
-            "            (will be rounded up to a multiple of 4096 bytes)\n"
+            " -z BYTES set the maximum job size in bytes (default is %d);\n"
+            "          max allowed is %d bytes\n"
+            " -s BYTES set the size of each write-ahead log file (default is %d);\n"
+            "          will be rounded up to a multiple of 4096 bytes\n"
             " -v       show version information\n"
             " -V       increase verbosity\n"
             " -h       show this help\n",
             progname,
+            DEFAULT_FSYNC_MS,
             JOB_DATA_SIZE_LIMIT_DEFAULT,
             JOB_DATA_SIZE_LIMIT_MAX,
             Filesizedef);


### PR DESCRIPTION
This won't result in degradation of speed but minimizes the data loss
on disk in the case of server crash.

Benchmarks to prove:
```
ctbench_put_delete_1024			    5000	    321840 ns/op	   4.83 MB/s
ctbench_put_delete_wal_1024_fsync_000ms	     100	  10783976 ns/op	   0.10 MB/s
ctbench_put_delete_wal_1024_fsync_050ms	    3000	    401186 ns/op	   3.01 MB/s
ctbench_put_delete_wal_1024_fsync_200ms	    3000	    372918 ns/op	   3.04 MB/s
ctbench_put_delete_wal_1024_no_fsync	    3000	    358677 ns/op	   3.05 MB/s

ctbench_put_delete_8192			    5000	    389117 ns/op	  37.42 MB/s
ctbench_put_delete_wal_8192_fsync_000ms	     200	   9642472 ns/op	   1.50 MB/s
ctbench_put_delete_wal_8192_fsync_050ms	    2000	    555952 ns/op	  16.20 MB/s
ctbench_put_delete_wal_8192_fsync_200ms	    2000	    524707 ns/op	  16.30 MB/s
ctbench_put_delete_wal_8192_no_fsync	    3000	    505258 ns/op	  23.37 MB/s
```
Fixes #548