### PR TITLE
exit when SIGTERM is received and pid is 1

### DIFF
--- a/main.c
+++ b/main.c
@@ -39,7 +39,7 @@ su(const char *user)
 static void
 handle_sigterm_pid1()
 {
-    raise(SIGKILL);
+    exit(143);
 }
 
 static void


### PR DESCRIPTION
In Linux SIGKILL is blocked for the process with pid of 1. Instead of
the process sending itself SIGKILL just exit at once.

Fixes #527