### PR TITLE
add stats for replayed jobs (#590)

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -88,6 +88,7 @@ struct stats {
     uint64 pause_ct;
     uint64 total_delete_ct;
     uint64 total_jobs_ct;
+    uint64 replayed_jobs_ct;
 };
 
 

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -532,6 +532,9 @@ keys to scalar values. It contains these keys:
  - "total-jobs" is the cumulative count of jobs created in this tube in
    the current beanstalkd process.
 
+ - "replayed-jobs" is the count of jobs created in this tube that were
+   obtained from the binlog on startup.
+
  - "current-using" is the number of open connections that are currently
    using this tube.
 
@@ -624,6 +627,8 @@ they are not stored on disk with the -b flag.
  - "job-timeouts" is the cumulative count of times a job has timed out.
 
  - "total-jobs" is the cumulative count of jobs created.
+
+ - "replayed-jobs" is the count of jobs obtained from the binlog on startup.
 
  - "max-job-size" is the maximum number of bytes in a job.
 


### PR DESCRIPTION
Added a new field to the `stats` struct to store the replayed job count on both a global level and per tube.

The counters are increased in `prot_replay` after the call to `enqueue_job` was successful.