### PR TITLE
Make sure to quote os value in stats cmd

### DIFF
--- a/prot.c
+++ b/prot.c
@@ -186,7 +186,7 @@ size_t job_data_size_limit = JOB_DATA_SIZE_LIMIT_DEFAULT;
     "draining: %s\n" \
     "id: %s\n" \
     "hostname: %s\n" \
-    "os: %s\n" \
+    "os: \"%s\"\n" \
     "platform: %s\n" \
     "\r\n"
 


### PR DESCRIPTION
This prevents invalid yaml value when os might contain colons (`:`) such as:
`Darwin Gilad-MBP 19.6.0 Darwin Kernel Version 19.6.0: Thu Jun 18 20:49:00 PDT 2020; root:xnu-6153.141.1~1/RELEASE_X86_64 x86_64`