### PR TITLE
Test failures on big-endian systems

### DIFF
--- a/testserv.c
+++ b/testserv.c
@@ -191,8 +191,8 @@ mustforksrv(void)
         exit(1);
     }
 
-    size_t len = sizeof(addr);
-    int r = getsockname(srv.sock.fd, (struct sockaddr *)&addr, (socklen_t *)&len);
+    socklen_t len = sizeof(addr);
+    int r = getsockname(srv.sock.fd, (struct sockaddr *)&addr, &len);
     if (r == -1 || len > sizeof(addr)) {
         puts("mustforksrv failed");
         exit(1);


### PR DESCRIPTION
Building beanstalkd on big-endian systems (such as s390x, ppc64 and sparc64) currently [fails on the test phase](https://buildd.debian.org/status/fetch.php?pkg=beanstalkd&arch=s390x&ver=1.12-1&stamp=1600854215&raw=0), indicating an error in `mustforksrv()`.

Digging a bit deeper, it turns out this is a type-casting issue between `size_t` (`unsigned long int`) and `socklen_t` (`unsigned int`): `size_t` is 8 bytes, while `socklen_t` is only 4 and these being big-endian systems, actually casting a `size_t *` pointer as `socklen_t *` will set the 4 most significant bytes, rather the least-significant ones, leading to unexpected results.

To better illustrate this, on s390x this code:
```C
 size_t sz = 0;
 *(socklen_t *)&sz = 4;
 printf("*(socklen_t *)&sz = %d, sz = %ld\n", *(socklen_t *)&sz, sz);
```
produces the following output:
```
 *(socklen_t *)&sz = 4, sz = 17179869184
```
where 17179869184 = 4 << 32

Fix this by avoiding the cast from `size_t` to `socklen_t` altogether.