### PR TITLE
Optimize small details to make code cleaner

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -50,7 +50,6 @@ make_conn(int fd, char start_state, Tube *use, Tube *watch)
     TUBE_ASSIGN(c->use, use);
     use->using_ct++;
 
-    c->sock.fd = fd;
     c->state = start_state;
     c->pending_timeout = -1;
     c->tickpos = 0; // Does not mean anything if in_conns is set to 0.

--- a/dat.h
+++ b/dat.h
@@ -326,7 +326,7 @@ extern struct Ms tubes;
 Tube *make_tube(const char *name);
 void  tube_dref(Tube *t);
 void  tube_iref(Tube *t);
-Tube *tube_find(const char *name);
+Tube *tube_find(Ms *tubeset, const char *name);
 Tube *tube_find_or_make(const char *name);
 #define TUBE_ASSIGN(a,b) (tube_dref(a), (a) = (b), tube_iref(a))
 

--- a/prot.c
+++ b/prot.c
@@ -461,6 +461,10 @@ process_queue()
 
     while ((j = next_awaited_job(now))) {
         j = remove_ready_job(j);
+        if (j == NULL) {
+            twarnx("job not ready");
+            continue;
+        }
         Conn *c = ms_take(&j->tube->waiting_conns);
         if (c == NULL) {
             twarnx("waiting_conns is empty");

--- a/prot.c
+++ b/prot.c
@@ -461,10 +461,6 @@ process_queue()
 
     while ((j = next_awaited_job(now))) {
         j = remove_ready_job(j);
-        if (j == NULL) {
-            continue; // precaution
-        }
-
         Conn *c = ms_take(&j->tube->waiting_conns);
         if (c == NULL) {
             twarnx("waiting_conns is empty");

--- a/prot.c
+++ b/prot.c
@@ -1700,7 +1700,7 @@ dispatch_cmd(Conn *c)
         }
         op_ct[type]++;
 
-        t = tube_find(name);
+        t = tube_find(&tubes, name);
         if (!t) {
             reply_msg(c, MSG_NOTFOUND);
             return;
@@ -1794,14 +1794,7 @@ dispatch_cmd(Conn *c)
         }
         op_ct[type]++;
 
-        t = NULL;
-        for (i = 0; i < c->watch.len; i++) {
-            t = c->watch.items[i];
-            if (strncmp(t->name, name, MAX_TUBE_NAME_LEN) == 0)
-                break;
-            t = NULL;
-        }
-
+        t = tube_find(&c->watch, name);
         if (t && c->watch.len < 2) {
             reply_msg(c, MSG_NOT_IGNORED);
             return;
@@ -1830,7 +1823,7 @@ dispatch_cmd(Conn *c)
             reply_msg(c, MSG_BAD_FORMAT);
             return;
         }
-        t = tube_find(name);
+        t = tube_find(&tubes, name);
         if (!t) {
             reply_msg(c, MSG_NOTFOUND);
             return;

--- a/tube.c
+++ b/tube.c
@@ -82,12 +82,12 @@ make_and_insert_tube(const char *name)
 }
 
 Tube *
-tube_find(const char *name)
+tube_find(Ms *tubeset, const char *name)
 {
     size_t i;
 
-    for (i = 0; i < tubes.len; i++) {
-        Tube *t = tubes.items[i];
+    for (i = 0; i < tubeset->len; i++) {
+        Tube *t = tubeset->items[i];
         if (strncmp(t->name, name, MAX_TUBE_NAME_LEN) == 0)
             return t;
     }
@@ -97,7 +97,7 @@ tube_find(const char *name)
 Tube *
 tube_find_or_make(const char *name)
 {
-    Tube *t = tube_find(name);
+    Tube *t = tube_find(&tubes, name);
     if (t)
         return t;
     return make_and_insert_tube(name);


### PR DESCRIPTION
### Modification
- Removed duplicated assignment for `conn.fd`
- Reused existed `remove_ready_job` to remove job from ready heap for `process_queue`
- Enhanced `tube_find` to find in specified tube sets and not just the global tubes, use it in `OP_IGNORE` handler.