### PR TITLE
fix default tube reference count initialized as 1

### DIFF
--- a/prot.c
+++ b/prot.c
@@ -2240,7 +2240,7 @@ h_accept(const int fd, const short which, Server *s)
         return;
     }
 
-    Tube* default_tube = tube_find_or_make("default");
+    Tube *default_tube = tube_find_or_make("default");
     Conn *c = make_conn(cfd, STATE_WANT_COMMAND, default_tube, default_tube);
     if (!c) {
         twarnx("make_conn() failed");

--- a/prot.c
+++ b/prot.c
@@ -232,8 +232,6 @@ static uint64 timeout_ct = 0;
 static uint64 op_ct[TOTAL_OPS] = {0};
 static struct stats global_stat = {0};
 
-static Tube *default_tube;
-
 // If drain_mode is 1, then server does not accept new jobs.
 // Variable is set by the SIGUSR1 handler.
 static volatile sig_atomic_t drain_mode = 0;
@@ -2242,6 +2240,7 @@ h_accept(const int fd, const short which, Server *s)
         return;
     }
 
+    Tube* default_tube = tube_find_or_make("default");
     Conn *c = make_conn(cfd, STATE_WANT_COMMAND, default_tube, default_tube);
     if (!c) {
         twarnx("make_conn() failed");
@@ -2298,10 +2297,6 @@ prot_init()
     }
 
     ms_init(&tubes, NULL, NULL);
-
-    default_tube = tube_find_or_make("default");
-    if (!default_tube)
-        twarnx("Out of memory during startup!");
 }
 
 // For each job in list, inserts the job into the appropriate data

--- a/prot.c
+++ b/prot.c
@@ -2299,7 +2299,7 @@ prot_init()
 
     ms_init(&tubes, NULL, NULL);
 
-    TUBE_ASSIGN(default_tube, tube_find_or_make("default"));
+    default_tube = tube_find_or_make("default");
     if (!default_tube)
         twarnx("Out of memory during startup!");
 }


### PR DESCRIPTION
### Issue
Tube `default` reference counts initialized as 1, means event if no connection watching or using it, it's still in memory and never gonna be garbage collected until close server, lead to `list-tubes` / `stats` / ... are not very accurate.
```shell
> telnet 127.0.0.1 11300
use tubeX
USING tubeX
watch tubeX
WATCHING 2
ignore default
WATCHING 1
list-tubes
OK 22
---
- default  # expect deleted
- tubeX

stats
OK 1054
---
cmd-use: 1
cmd-watch: 1
cmd-ignore: 1
cmd-stats: 1
cmd-list-tubes: 1
current-tubes: 2  # expect 1
#...
```

### Modification
When new connection accepted, find or make `default` tube for it, and without macro `TUBE_ASSIGN` that has side effects, the re-make operation maybe low frequency.

### Others 
This design has the advantage of avoiding the default tube being re-make frequently, and users may not care why stats are not accurate enough. If so, it's ok to close this PR.