### PR TITLE
Build beanstalkd and run PHP Pheanstalk and Python Greenstalk testsuites against it

### DIFF
--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -55,9 +55,9 @@ jobs:
         with:
           name: beanstalkd
       - name: Make beanstalkd executable
-        run: chmod +x ${{steps.download.outputs.download-path}}
+        run: chmod +x ${{steps.download.outputs.download-path}}/beanstalkd
       - name: Run beanstalkd -v
-        run: ${{steps.download.outputs.download-path}} -v
+        run: ${{steps.download.outputs.download-path}}/beanstalkd -v
       - uses: actions/checkout@v2
         with:
           repository: justinmayhew/greenstalk
@@ -67,5 +67,5 @@ jobs:
           pip install --use-feature=in-tree-build .
       - name: Run tests
         env:
-          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}
+          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}/beanstalkd
         run: make test

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -53,9 +53,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: beanstalkd
-          path: /
+      - name: 'Echo download path'
+        run: echo ${{steps.download.outputs.download-path}}
       - name: Make beanstalkd executable
-        run: chmod +x /beanstalkd
+        run: chmod +x ${{steps.download.outputs.download-path}}
       - uses: actions/checkout@v2
         with:
           repository: justinmayhew/greenstalk
@@ -65,5 +66,5 @@ jobs:
           pip install --use-feature=in-tree-build .
       - name: Run tests
         env:
-          BEANSTALKD_PATH: /beanstalkd
+          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}
         run: make test

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -64,8 +64,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install pytest
-          pip install --use-feature=in-tree-build .
+          pip install .
       - name: Run tests
         env:
           BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}/beanstalkd
-        run: make test
+        run: ls -lah ${{steps.download.outputs.download-path}} && make test

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -1,0 +1,37 @@
+name: Integration test for beanstalk clients
+on: push
+jobs:
+  build:
+    name: Build beanstalkd
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make
+      - uses: actions/upload-artifact@v2
+        with:
+          name: beanstalkd
+          path: beanstalkd
+  pheanstalk:
+    name: Test against Pheanstalk PHP client
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: phpunit
+      - uses: actions/download-artifact@v2
+        with:
+          name: beanstalkd
+      - name: Start beanstalkd
+        run: chmod +x ./beanstalkd && ./beanstalkd &
+      - uses: actions/checkout@v2
+        with:
+          repository: pheanstalk/pheanstalk
+          ref: v5
+      - name: Install dependencies including dev-dependencies
+        run: composer install
+      - name: Run PHPUnit tests
+        run: phpunit

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -37,3 +37,32 @@ jobs:
         run: composer install
       - name: Run PHPUnit tests
         run: phpunit
+  greenstalk:
+    name: Test against Greenstalk Python client
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ 3.9, 3.8, 3.7, 3.6 ]
+    needs:
+      - build
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: beanstalkd
+      - name: Make beanstalkd executable
+        run: chmod +x ./beanstalkd
+      - uses: actions/checkout@v2
+        with:
+          repository: justinmayhew/greenstalk
+      - name: Install dependencies
+        run: |
+          pip install pytest
+          pip install --use-feature=in-tree-build .
+      - name: Run tests
+        env:
+          BEANSTALKD_PATH: ./beanstalkd
+        run: make test

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -54,10 +54,10 @@ jobs:
         id: download
         with:
           name: beanstalkd
-      - name: 'Echo download path'
-        run: echo ${{steps.download.outputs.download-path}}
       - name: Make beanstalkd executable
         run: chmod +x ${{steps.download.outputs.download-path}}
+      - name: Run beanstalkd -v
+        run: ${{steps.download.outputs.download-path}} -v
       - uses: actions/checkout@v2
         with:
           repository: justinmayhew/greenstalk

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -50,6 +50,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v2
+        with:
+          repository: justinmayhew/greenstalk
       - uses: actions/download-artifact@v2
         id: download
         with:
@@ -58,9 +61,7 @@ jobs:
         run: chmod +x ${{steps.download.outputs.download-path}}/beanstalkd
       - name: Run beanstalkd -v
         run: ${{steps.download.outputs.download-path}}/beanstalkd -v
-      - uses: actions/checkout@v2
-        with:
-          repository: justinmayhew/greenstalk
+
       - name: Install dependencies
         run: |
           pip install pytest
@@ -68,4 +69,4 @@ jobs:
       - name: Run tests
         env:
           BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}/beanstalkd
-        run: ls -lah ${{steps.download.outputs.download-path}} && make test
+        run: make test

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -51,6 +51,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/download-artifact@v2
+        id: download
         with:
           name: beanstalkd
       - name: 'Echo download path'

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: beanstalkd
-          path: /beanstalkd
+          path: /
       - name: Make beanstalkd executable
         run: chmod +x /beanstalkd
       - uses: actions/checkout@v2

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.9, 3.8, 3.7, 3.6 ]
+        python-version: [ 3.9 ]
     needs:
       - build
     steps:
@@ -53,9 +53,9 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: beanstalkd
-          path: /bin/beanstalkd
+          path: /beanstalkd
       - name: Make beanstalkd executable
-        run: chmod +x /bin/beanstalkd
+        run: chmod +x /beanstalkd
       - uses: actions/checkout@v2
         with:
           repository: justinmayhew/greenstalk
@@ -65,5 +65,5 @@ jobs:
           pip install --use-feature=in-tree-build .
       - name: Run tests
         env:
-          BEANSTALKD_PATH: /bin/beanstalkd
+          BEANSTALKD_PATH: /beanstalkd
         run: make test

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -1,5 +1,7 @@
 name: Integration test for beanstalk clients
-on: push
+on:
+  - push
+  - pull_request
 jobs:
   build:
     name: Build beanstalkd

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -53,8 +53,9 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: beanstalkd
+          path: /bin/beanstalkd
       - name: Make beanstalkd executable
-        run: chmod +x ./beanstalkd
+        run: chmod +x /bin/beanstalkd
       - uses: actions/checkout@v2
         with:
           repository: justinmayhew/greenstalk
@@ -64,5 +65,5 @@ jobs:
           pip install --use-feature=in-tree-build .
       - name: Run tests
         env:
-          BEANSTALKD_PATH: ./beanstalkd
+          BEANSTALKD_PATH: /bin/beanstalkd
         run: make test


### PR DESCRIPTION
This sets up a github action that:
- Builds beanstalkd on any push
- Runs the Pheanstalk test suite against the daemon


It's easily extensible to include other clients.
The idea behind this is that any push or PR confirms that clients won't break (or allows us to identify which clients break and thus give us an early warning for required downstream changes / fixes)