### PR TITLE
Support different base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,13 @@
+ARG BASE=alpine
 FROM alpine as builder
-
-RUN \
-	apk -U upgrade --no-cache && \
-	apk add --no-cache build-base git 
-
+RUN apk add --no-cache build-base git
 COPY . /tmp/beanstalkd
-RUN \ 
-	cd /tmp/beanstalkd && \
-	make 
+RUN cd /tmp/beanstalkd && make
 
 ################################
-FROM alpine
-
-RUN apk -U upgrade --no-cache 
+ARG BASE
+FROM ${BASE}
 
 COPY --from=builder /tmp/beanstalkd/beanstalkd /usr/bin/
-
-RUN mkdir /beanstalkd
 EXPOSE 11300
 ENTRYPOINT ["/usr/bin/beanstalkd"]


### PR DESCRIPTION
Support a different base image via build args.

Fixes #603 


Allows users who prefer to self-build to use their own base image with our dockerfile:

`docker build . --build-arg BASE=ubuntu:latest`

Will build beanstalkd then put it into the specified base image!