### PR TITLE
Update beanstalkd.service

### DIFF
--- a/adm/systemd/beanstalkd.service
+++ b/adm/systemd/beanstalkd.service
@@ -4,3 +4,6 @@ Description=Beanstalkd is a simple, fast work queue
 [Service]
 User=nobody
 ExecStart=/usr/bin/beanstalkd
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Fixes "The unit files have no installation config (WantedBy, RequiredBy, Also, Alias
settings in the [Install] section, and DefaultInstance for template units)."