### PR TITLE
Build beanstalkd and run PHP Pheanstalk and Python Greenstalk testsuites against it 

### DIFF
--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -1,0 +1,72 @@
+name: Integration test for beanstalk clients
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    name: Build beanstalkd
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make
+      - uses: actions/upload-artifact@v2
+        with:
+          name: beanstalkd
+          path: beanstalkd
+  pheanstalk:
+    name: Test against Pheanstalk PHP client
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: phpunit
+      - uses: actions/download-artifact@v2
+        with:
+          name: beanstalkd
+      - name: Start beanstalkd
+        run: chmod +x ./beanstalkd && ./beanstalkd &
+      - uses: actions/checkout@v2
+        with:
+          repository: pheanstalk/pheanstalk
+          ref: v5
+      - name: Install dependencies including dev-dependencies
+        run: composer install
+      - name: Run PHPUnit tests
+        run: phpunit
+  greenstalk:
+    name: Test against Greenstalk Python client
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ 3.9 ]
+    needs:
+      - build
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v2
+        with:
+          repository: justinmayhew/greenstalk
+      - uses: actions/download-artifact@v2
+        id: download
+        with:
+          name: beanstalkd
+      - name: Make beanstalkd executable
+        run: chmod +x ${{steps.download.outputs.download-path}}/beanstalkd
+      - name: Run beanstalkd -v
+        run: ${{steps.download.outputs.download-path}}/beanstalkd -v
+
+      - name: Install dependencies
+        run: |
+          pip install pytest
+          pip install .
+      - name: Run tests
+        env:
+          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}/beanstalkd
+        run: make test


### PR DESCRIPTION
This sets up a github action that:
- Builds beanstalkd on any push
- Runs the Pheanstalk test suite against the daemon


It's easily extensible to include other clients.
The idea behind this is that any push or PR confirms that clients won't break (or allows us to identify which clients break and thus give us an early warning for required downstream changes / fixes)