### PR TITLE
Fixes permissions on wal file to allow running within OpenShift

### DIFF
--- a/walg.c
+++ b/walg.c
@@ -410,7 +410,7 @@ waldirlock(Wal *w)
     }
     snprintf(path, path_length, "%s/lock", w->dir);
 
-    fd = open(path, O_WRONLY|O_CREAT, 0600);
+    fd = open(path, O_WRONLY|O_CREAT, 0660);
     free(path);
     if (fd == -1) {
         twarn("open");


### PR DESCRIPTION
* OpenShift runs containers with random UIDs[1]. 
* OpenShift runs containers with the GID set to `root`
* Running beanstalkd in a container, it will not be able to read it's WAL file on restart if/when the UID changes. 
* This fix changes the default perms on the WAL file to be group r/w. 

[1] https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids