### PR TITLE
Add abortable reserve command

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -202,6 +202,10 @@ Alternatively, you can specify a timeout as follows:
 
     reserve-with-timeout <seconds>\r\n
 
+Or keep control over the duration of the command at the client as follows:
+
+    reserve-with-abort\r\n
+
 This will return a newly-reserved job. If no job is available to be reserved,
 beanstalkd will wait to send a response until one becomes available. Once a
 job is reserved for the client, the client has limited time to run (TTR) the
@@ -217,6 +221,11 @@ A timeout value of 0 will cause the server to immediately return either a
 response or TIMED_OUT.  A positive value of timeout will limit the amount of
 time the client will block on the reserve request until a job becomes
 available.
+
+When using reserve-with-abort, no timeout is observed by the server, but the
+command will be aborted by any subsequent command sent by the client. Sending
+any command while reserve-with-abort is active, will abort the reserve command
+and make it return ABORTED.
 
 During the TTR of a reserved job, the last second is kept by the server as a
 safety margin, during which the client will not be made to wait for another

--- a/testserv.c
+++ b/testserv.c
@@ -1118,6 +1118,18 @@ cttest_reserve_with_timeout_2conns()
 }
 
 void
+cttest_reserve_with_abort()
+{
+    int port = SERVER();
+    int fd = mustdiallocal(port);
+    mustsend(fd, "reserve-with-abort\r\n");
+    usleep(100000);
+    mustsend(fd, "watch foo\r\n");
+    ckresp(fd, "ABORTED\r\n");
+    ckresp(fd, "WATCHING 2\r\n");
+}
+
+void
 cttest_reserve_ttr_deadline_soon()
 {
     int port = SERVER();


### PR DESCRIPTION
In a couple of projects, we have a need to add or remove watched tubes due to external events.

At first, we implemented this by always using a timeout of 1 second for reserve-with-timeout, but this always introduces a latency between 0 and 1 seconds when a new tube has to be watched while a reserve-with-timeout is active. We considered using a timeout of 0 seconds in a tight loop, so we can quickly respond to the external event, but this would unnecessarily increase system resource usage. We figured an ideal solution would be to have the possibility to issue a reserve command and to be able to abort it.

This pull requests implements this behaviour by introducing a reserve-with-abort command. It effectively works the same as the reserve command, so without a server enforced timeout, but it keeps an eye on incoming data from the client. Whenever any data is observed (either in the cmd_read buffer, or by observing an epoll event), the wait is aborted.

This satisfies our requirements, as sending a watch or ignore command will abort the reserve-with-abort, causing our client to queue a new reserve-with-abort after the watch or ignore command automatically. As evidenced by some discussions, both on issues in this project and in the popular Go client library, this functionality may come in handy for more users.