### PR TITLE
Add multi-architecture Docker builds for tagged releases

### DIFF
--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -6,8 +6,11 @@ on:
       - 'v*'
 jobs:
   tests:
-    name: Tests
-    runs-on: ubuntu-latest
+    name: Tests on ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+        matrix:
+          runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v4
       - name: Tests

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -13,6 +13,9 @@ jobs:
       - name: Tests
         run: make check
   build:
+    permissions:
+      packages: write
+      contents: read
     name: Docker build
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -1,15 +1,15 @@
 ---
-name: Continous integration
+name: Continuous integration
 on:
   push:
-    branches:
-      - master
+    tags:
+      - 'v*'
 jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Tests
         run: make check
   build:
@@ -18,12 +18,27 @@ jobs:
     needs:
       - tests
     steps:
-      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx with QEMU
+        uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v3
+      - uses: actions/checkout@v4
+      - name: Convert relevant environment variables
+        id: convert
+        run: |
+          echo "REPO=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          echo "TAG_VERSION=$(echo '${{ github.ref_name }}' | sed 's/^v//')" >> $GITHUB_ENV
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - run: docker build . -t `echo ghcr.io/${{ github.repository }}:latest | tr '[:upper:]' '[:lower:]'`
-      - run: docker push `echo ghcr.io/${{ github.repository }}:latest | tr '[:upper:]' '[:lower:]'`
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ env.REPO }}:latest
+            ghcr.io/${{ env.REPO }}:${{ env.TAG_VERSION }}

--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -7,8 +7,11 @@ on:
       - master
 jobs:
   tests:
-    name: Tests
-    runs-on: ubuntu-latest
+    name: Tests on ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v4
       - name: Tests

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -7,9 +7,9 @@ jobs:
     name: Build beanstalkd
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: make
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: beanstalkd
           path: beanstalkd
@@ -25,7 +25,7 @@ jobs:
         with:
           php-version: '8.1'
           tools: phpunit
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: beanstalkd
       - name: Start beanstalkd
@@ -56,12 +56,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: justinmayhew/greenstalk
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         id: download
         with:
+          #include-hidden-files: true
           name: beanstalkd
       - name: Make beanstalkd executable
         run: chmod +x ${{steps.download.outputs.download-path}}/beanstalkd
@@ -90,10 +91,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: EasyPost/pystalk
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         id: download
         with:
           name: beanstalkd

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -5,17 +5,23 @@ on:
 jobs:
   build:
     name: Build beanstalkd
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v4
       - run: make
       - uses: actions/upload-artifact@v4
         with:
-          name: beanstalkd
+          name: beanstalkd-${{ matrix.runner }}
           path: beanstalkd
   pheanstalk:
     name: Test Pheanstalk PHP
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     continue-on-error: true
     needs:
       - build
@@ -27,8 +33,8 @@ jobs:
           tools: phpunit
       - uses: actions/download-artifact@v4
         with:
-          name: beanstalkd
-      - name: Start beanstalkd
+          name: beanstalkd-${{ matrix.runner }}
+      - name: Start beanstalkd for ${{ matrix.runner }}
         run: chmod +x ./beanstalkd && ./beanstalkd &
       - uses: actions/checkout@v4
         with:
@@ -42,11 +48,12 @@ jobs:
           SERVER_HOST: localhost
   greenstalk:
     name: Test Greenstalk Python
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     continue-on-error: true
     strategy:
       matrix:
         python-version: [ 3.9 ]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     needs:
       - build
     steps:
@@ -61,8 +68,8 @@ jobs:
         id: download
         with:
           #include-hidden-files: true
-          name: beanstalkd
-      - name: Make beanstalkd executable
+          name: beanstalkd-${{ matrix.runner }}
+      - name: Make beanstalkd executable for ${{ matrix.runner }}
         run: chmod +x ${{steps.download.outputs.download-path}}/beanstalkd
       - name: Run beanstalkd -v
         run: ${{steps.download.outputs.download-path}}/beanstalkd -v
@@ -77,11 +84,12 @@ jobs:
         run: make test
   pystalk:
     name: Test Pystalk Python
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     continue-on-error: true
     strategy:
       matrix:
         python-version: [ "3.10" ]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     needs:
       - build
     steps:
@@ -95,8 +103,8 @@ jobs:
       - uses: actions/download-artifact@v4
         id: download
         with:
-          name: beanstalkd
-      - name: Make beanstalkd executable
+          name: beanstalkd-${{ matrix.runner }}
+      - name: Make beanstalkd executable for ${{ matrix.runner }}
         run: chmod +x ${{steps.download.outputs.download-path}}/beanstalkd
       - name: Run beanstalkd -v
         run: ${{steps.download.outputs.download-path}}/beanstalkd -v


### PR DESCRIPTION
This PR targets the possibility to automate Docker builds for both `linux/amd64` and `linux/arm64` platforms.

Looking for an easy way to add Beanstalkd to my containerized apps, I realized there were a lot of seldomly maintained repositories on Docker Hub and this repository haven't gotten any version tagged builds as well as no build with the latest release.

While I acknowledge this change might not justify a minor release, I hope this PR could pave the way for a maintainable automated build and push setup.

Minor changes to the workflow named "Testing clients" due to failing pipelines as officially supported actions was deprecated earlier this year. 

Fixes #648, fixes #661