### PR TITLE
Fix handle_sigterm_pid1() signature

### DIFF
--- a/main.c
+++ b/main.c
@@ -37,7 +37,7 @@ su(const char *user)
 }
 
 static void
-handle_sigterm_pid1()
+handle_sigterm_pid1(int _unused)
 {
     exit(143);
 }


### PR DESCRIPTION
This is a signal handler, so it should accept a signal number as the only argument, otherwise GCC 15 fails with the following error:

```
  main.c: In function 'set_sig_handlers':
  main.c:75:23: error: assignment to '__sighandler_t' {aka 'void (*)(int)'} from incompatible pointer type 'void (*)(void)' [-Wincompatible-pointer-types]
     75 |         sa.sa_handler = handle_sigterm_pid1;
        |                       ^
  main.c:40:1: note: 'handle_sigterm_pid1' declared here
     40 | handle_sigterm_pid1()
        | ^~~~~~~~~~~~~~~~~~~
  In file included from main.c:3:
  /usr/include/signal.h:72:16: note: '__sighandler_t' declared here
     72 | typedef void (*__sighandler_t) (int);
        |                ^~~~~~~~~~~~~~
```

See also https://bugs.debian.org/1096364.