### PR TITLE
Add sub-second precision delay support for put, release, and pause-tube

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Simple and fast general purpose work queue. 
 
 ***This version allows for sub-second delay resolution - you may need to change the client library that you are using to pass the delay as a float. eg: 1.456 seconds***
-***Alert: Performance hits are not measured.***
+***Alert: Performance hits are not measured. It should be fast***
 
 https://beanstalkd.github.io/
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 
 # beanstalkd
 
-Simple and fast general purpose work queue.
+Simple and fast general purpose work queue. 
+***This version allows for sub-second delay resolution - you may need to change the client library that you are using to pass the delay as a float. eg: 1.456 seconds***
+***Alert: Performance hits are not measured.***
 
 https://beanstalkd.github.io/
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@
 
 Simple and fast general purpose work queue. 
 
-***This version allows for sub-second delay resolution - you may need to change the client library that you are using to pass the delay as a float. eg: 1.456 seconds***
-***Alert: Performance hits are not measured. It should be fast***
-
 https://beanstalkd.github.io/
 
 See [doc/protocol.txt](https://github.com/beanstalkd/beanstalkd/blob/master/doc/protocol.txt)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 # beanstalkd
 
 Simple and fast general purpose work queue. 
+
 ***This version allows for sub-second delay resolution - you may need to change the client library that you are using to pass the delay as a float. eg: 1.456 seconds***
 ***Alert: Performance hits are not measured.***
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # beanstalkd
 
-Simple and fast general purpose work queue. 
+Simple and fast general purpose work queue.
 
 https://beanstalkd.github.io/
 

--- a/prot.c
+++ b/prot.c
@@ -1078,7 +1078,7 @@ read_duration(int64 *duration, const char *buf, char **end)
 }
 
 // Function to compute 10^n
-double my_pow10(int n) {
+double atof_pow10(int n) {
     double ret = 1.0;
     double r = 10.0;
     if (n < 0) {
@@ -1149,7 +1149,7 @@ static double crack_atof(const char *num, const char **end) {
             exp_val = exp_val * 10 + (*ptr - '0');
             ptr++;
         }
-        exp_part = my_pow10(exp_sign * exp_val);
+        exp_part = atof_pow10(exp_sign * exp_val);
     }
 
     // Update end pointer


### PR DESCRIPTION
Delays can  be specified with fractional seconds, supporting formats like '1.543', '0.43', or scientific notation like '1.25e-1'.

#103

Integer values are still supported, so this change should be backward-compatible with existing behavior.

While not yet performance-benchmarked, the parser is expected to be fast — it handles doubles directly and minimizes logic when parsing integers.

Parsing is handled by a "custom" CRACK_ATOF function. See:
https://github.com/shaovoon/floatbench
https://gist.github.com/oschonrock/a410d4bec6ec1ccc5a3009f0907b3d15

